### PR TITLE
Enable SMTPUTF8 in SMTP server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,8 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+replace git.mills.io/prologic/smtpd => ./internal/smtpd
+
 require (
 	aead.dev/minisign v0.2.0 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 aead.dev/minisign v0.2.0 h1:kAWrq/hBRu4AARY6AlciO83xhNnW9UaC8YipS2uhLPk=
 aead.dev/minisign v0.2.0/go.mod h1:zdq6LdSd9TbuSxchxwhpA9zEb9YXcVGoE8JakuiGaIQ=
 cloud.google.com/go/compute/metadata v0.2.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
-git.mills.io/prologic/smtpd v0.0.0-20210710122116-a525b76c287a h1:3i+FJ7IpSZHL+VAjtpQeZCRhrpP0odl5XfoLBY4fxJ8=
-git.mills.io/prologic/smtpd v0.0.0-20210710122116-a525b76c287a/go.mod h1:C7hXLmFmPYPjIDGfQl1clsmQ5TMEQfmzWTrJk475bUs=
 github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
 github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Mzack9999/gcache v0.0.0-20230410081825-519e28eab057 h1:KFac3SiGbId8ub47e7kd2PLZeACxc1LkiiNoDOFRClE=

--- a/internal/smtpd/LICENSE
+++ b/internal/smtpd/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/internal/smtpd/go.mod
+++ b/internal/smtpd/go.mod
@@ -1,0 +1,3 @@
+module git.mills.io/prologic/smtpd
+
+go 1.21

--- a/internal/smtpd/readme.md
+++ b/internal/smtpd/readme.md
@@ -1,0 +1,217 @@
+# smtpd
+
+An SMTP server package written in Go, in the style of the built-in HTTP server. It meets the minimum requirements specified by RFC 2821 & 5321.
+
+It is based on [Brad Fitzpatrick's go-smtpd](https://github.com/bradfitz/go-smtpd). The differences can be summarised as:
+
+* A simplified message handler
+* Changes made for RFC compliance
+* Testing has been added
+* Code refactoring
+* TLS support
+* RCPT handler
+* Authentication support
+
+## Features
+
+* A single message handler for simple mail handling with native data types.
+* RFC compliance. It implements the minimum command set, responds to commands and adds a valid Received header to messages as specified in RFC 2821 & 5321.
+* Customisable listening address and port. It defaults to listening on all addresses on port 25 if unset.
+* Customisable host name and application name. It defaults to the system hostname and "smtpd" application name if they are unset.
+* Easy to use TLS support that obeys RFC 3207.
+* Authentication support for the CRAM-MD5, LOGIN and PLAIN mechanisms that obeys RFC 4954.
+
+## Usage
+
+In general: create the server and pass a handler function to it as for the HTTP server. The server function has the following definition:
+
+```go
+func ListenAndServe(addr string, handler Handler, appname string, hostname string) error
+```
+
+For TLS support, add the paths to the certificate and key files as for the HTTP server.
+
+```go
+func ListenAndServeTLS(addr string, certFile string, keyFile string, handler Handler, appname string, hostname string) error
+```
+
+The handler function must have the following definition:
+
+```go
+func handler(remoteAddr net.Addr, from string, to []string, data []byte)
+```
+
+The parameters are:
+
+* remoteAddr: remote end of the TCP connection i.e. the mail client's IP address and port.
+* from: the email address sent by the client in the MAIL command.
+* to: the set of email addresses sent by the client in the RCPT command.
+* data: the raw bytes of the mail message.
+
+## TLS Support
+
+SMTP over TLS works slightly differently to how you might expect if you are used to the HTTP protocol. Some helpful links for background information are:
+
+* [SSL vs TLS vs STARTTLS](https://www.fastmail.com/help/technical/ssltlsstarttls.html)
+* [Opportunistic TLS](https://en.wikipedia.org/wiki/Opportunistic_TLS)
+* [RFC 2487: SMTP Service Extension for Secure SMTP over TLS](https://tools.ietf.org/html/rfc2487)
+* [func (*Client) StartTLS](https://golang.org/pkg/net/smtp/#Client.StartTLS)
+
+The TLS support has three server configuration options. The bare minimum requirement to enable TLS is to supply certificate and key files as in the TLS example below.
+
+* TLSConfig
+
+This option allows custom TLS configurations such as [requiring strong ciphers](https://cipherli.st/) or using other certificate creation methods. If a certificate file and a key file are supplied to the ConfigureTLS function, the default TLS configuration for Go will be used. The default value for TLSConfig is nil, which disables TLS support.
+
+* TLSRequired
+
+This option sets whether TLS is optional or required. If set to true, the only allowed commands are NOOP, EHLO, STARTTLS and QUIT (as specified in RFC 3207) until the connection is upgraded to TLS i.e. until STARTTLS is issued. This option is ignored if TLS is not configured i.e. if TLSConfig is nil. The default is false.
+
+* TLSListener
+
+This option sets whether the listening socket requires an immediate TLS handshake after connecting. It is equivalent to using HTTPS in web servers, or the now defunct SMTPS on port 465. This option is ignored if TLS is not configured i.e. if TLSConfig is nil. The default is false.
+
+There is also a related package configuration option.
+
+* Debug
+
+This option determines if the data being read from or written to the client will be logged. This may help with debugging when using encrypted connections. The default is false.
+
+## Authentication Support
+
+The authentication support offers three mechanisms (CRAM-MD5, LOGIN and PLAIN) and has three server configuration options. The bare minimum requirement to enable authentication is to supply an authentication handler function as in the authentication example below.
+
+* AuthHandler
+
+This option provides an authentication handler function which is called to determine the validity of the supplied credentials.
+
+* AuthMechs
+
+This option allows the list of allowed authentication mechanisms to be explicitly set, overriding the default settings.
+
+* AuthRequired
+
+This option sets whether authentication is optional or required. If set to true, the only allowed commands are AUTH, EHLO, HELO, NOOP, RSET and QUIT (as specified in RFC 4954) until the session is authenticated. This option is ignored if authentication is not configured i.e. if AuthHandler is nil. The default is false.
+
+If both TLS and authentication are required, the TLS requirements take priority.
+
+### Notes
+
+RFC 4954 specifies that the LOGIN and PLAIN mechanisms require TLS to be in use as they send the password in plaintext. By default, smtpd follows this requirement, and will not advertise or allow LOGIN and PLAIN until a TLS connection is established. This behaviour can be overridden during testing by using the AuthMechs option. For example, to enable the PLAIN mechanism regardless of TLS:
+
+```go
+mechs := map[string]bool{"PLAIN": true}
+srv := &smtpd.Server{AuthMechs: mechs, ...}
+```
+
+The LOGIN and PLAIN mechanisms send the password to the server, but CRAM-MD5 does not - it sends a hash of the password, with a salt supplied by the server. In order to authenticate a session using CRAM-MD5, the server must have access to the plaintext password so it can hash it with the same salt and compare it to the hash sent by the client. If passwords are stored in a hashed format (and they should be), they cannot be transformed into plaintext, and therefore CRAM-MD5 cannot be used. To disable the CRAM-MD5 mechanism:
+
+```go
+mechs := map[string]bool{"CRAM-MD5": false}
+srv := &smtpd.Server{AuthMechs: mechs, ...}
+```
+
+The Go SMTP client cancels the authentication exchange by sending an asterisk to the server after a failed authentication attempt. The server will ignore this behaviour.
+
+## Example
+
+The following example code creates a new server with the name "MyServerApp" that listens on the localhost address and port 2525. Upon receipt of a new mail message, the handler function parses the mail and prints the subject header.
+
+```go
+package main
+
+import (
+    "bytes"
+    "log"
+    "net"
+    "net/mail"
+
+    "github.com/mhale/smtpd"
+)
+
+func mailHandler(origin net.Addr, from string, to []string, data []byte) {
+    msg, _ := mail.ReadMessage(bytes.NewReader(data))
+    subject := msg.Header.Get("Subject")
+    log.Printf("Received mail from %s for %s with subject %s", from, to[0], subject)
+}
+
+func main() {
+    smtpd.ListenAndServe("127.0.0.1:2525", mailHandler, "MyServerApp", "")
+}
+```
+
+## TLS Example
+
+Using the example code above, only the main function would be different to add TLS support.
+
+```go
+func main() {
+    smtpd.ListenAndServeTLS("127.0.0.1:2525", "/path/to/server.crt", "/path/to/server.key", mailHandler, "MyServerApp", "")
+}
+```
+
+This allows STARTTLS to be listed as a supported extension and allows clients to upgrade connections to TLS by sending a STARTTLS command.
+
+As the package level helper functions do not set the TLSRequired or TLSListener options for compatibility reasons, manual creation of a Server struct is necessary in order to use them.
+
+## RCPT Handler Example
+
+With the same ```mailHandler``` as above:
+
+```go
+func rcptHandler(remoteAddr net.Addr, from string, to string) bool {
+    domain = getDomain(to)
+    return domain == "mail.example.com"
+}
+
+func ListenAndServe(addr string, handler smtpd.Handler, rcpt smtpd.HandlerRcpt) error {
+    srv := &smtpd.Server{
+        Addr:        addr,
+        Handler:     handler,
+        HandlerRcpt: rcpt,
+        Appname:     "MyServerApp",
+        Hostname:    "",
+    }
+    return srv.ListenAndServe()
+}
+
+ListenAndServe("127.0.0.1:2525", mailHandler, rcptHandler)
+```
+
+## Authentication Example
+
+With the same ```mailHandler``` as above:
+
+```go
+func authHandler(remoteAddr net.Addr, mechanism string, username []byte, password []byte, shared []byte) (bool, error) {
+    return string(username) == "valid" && string(password) == "password", nil
+}
+
+func ListenAndServe(addr string, handler smtpd.Handler, authHandler smtpd.AuthHandler) error {
+    srv := &smtpd.Server{
+        Addr:        addr,
+        Handler:     handler,
+        Appname:     "MyServerApp",
+        Hostname:    "",
+        AuthHandler: authHandler,
+        AuthRequired: true,
+    }
+    return srv.ListenAndServe()
+}
+
+ListenAndServe("127.0.0.1:2525", mailHandler, authHandler)
+```
+
+This allows AUTH to be listed as a supported extension, CRAM-MD5 as a supported mechanism, and allows clients to authenticate by sending an AUTH command.
+
+## Testing
+
+The tests cover the supported SMTP command set and line parsing. A single server is created listening on an ephemeral port (52525) for the duration of the tests. Each test creates a new client connection for processing commands.
+
+For the TLS, size and authentication tests, a different server is created with a net.Pipe connection inside each individual test, in order to change the server settings for each test.
+
+The TLS and authentication support has also been manually tested with Go client code, Ruby client code, and macOS's Mail.app.
+
+## Licensing
+
+Some of the code in this package was copied or adapted from code found in [Brad Fitzpatrick's go-smtpd](https://github.com/bradfitz/go-smtpd). As such, those sections of code are subject to their original copyright and license. The remaining code is in the public domain.

--- a/internal/smtpd/smtpd.go
+++ b/internal/smtpd/smtpd.go
@@ -1,0 +1,781 @@
+// Package smtpd implements a basic SMTP server.
+package smtpd
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var (
+	// Debug `true` enables verbose logging.
+	Debug      = false
+	rcptToRE   = regexp.MustCompile(`[Tt][Oo]:\s?<(.+)>`)
+	mailFromRE = regexp.MustCompile(`[Ff][Rr][Oo][Mm]:\s?<(.*)>(\s(.*))?`) // Delivery Status Notifications are sent with "MAIL FROM:<>"
+	mailSizeRE = regexp.MustCompile(`[Ss][Ii][Zz][Ee]=(\d+)`)
+)
+
+// Handler function called upon successful receipt of an email.
+type Handler func(remoteAddr net.Addr, from string, to []string, data []byte) error
+
+// HandlerRcpt function called on RCPT. Return accept status.
+type HandlerRcpt func(remoteAddr net.Addr, from string, to string) bool
+
+// AuthHandler function called when a login attempt is performed. Returns true if credentials are correct.
+type AuthHandler func(remoteAddr net.Addr, mechanism string, username []byte, password []byte, shared []byte) (bool, error)
+
+// ListenAndServe listens on the TCP network address addr
+// and then calls Serve with handler to handle requests
+// on incoming connections.
+func ListenAndServe(addr string, handler Handler, appname string, hostname string) error {
+	srv := &Server{Addr: addr, Handler: handler, Appname: appname, Hostname: hostname}
+	return srv.ListenAndServe()
+}
+
+// ListenAndServeTLS listens on the TCP network address addr
+// and then calls Serve with handler to handle requests
+// on incoming connections. Connections may be upgraded to TLS if the client requests it.
+func ListenAndServeTLS(addr string, certFile string, keyFile string, handler Handler, appname string, hostname string) error {
+	srv := &Server{Addr: addr, Handler: handler, Appname: appname, Hostname: hostname}
+	err := srv.ConfigureTLS(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+	return srv.ListenAndServe()
+}
+
+type maxSizeExceededError struct {
+	limit int
+}
+
+func maxSizeExceeded(limit int) maxSizeExceededError {
+	return maxSizeExceededError{limit}
+}
+
+// Error uses the RFC 5321 response message in preference to RFC 1870.
+// RFC 3463 defines enhanced status code x.3.4 as "Message too big for system".
+func (err maxSizeExceededError) Error() string {
+	return fmt.Sprintf("552 5.3.4 Requested mail action aborted: exceeded storage allocation (%d)", err.limit)
+}
+
+// LogFunc is a function capable of logging the client-server communication.
+type LogFunc func(remoteIP, verb, line string)
+
+// Server is an SMTP server.
+type Server struct {
+	Addr         string // TCP address to listen on, defaults to ":25" (all addresses, port 25) if empty
+	Appname      string
+	AuthHandler  AuthHandler
+	AuthMechs    map[string]bool // Override list of allowed authentication mechanisms. Currently supported: LOGIN, PLAIN, CRAM-MD5. Enabling LOGIN and PLAIN will reduce RFC 4954 compliance.
+	AuthRequired bool            // Require authentication for every command except AUTH, EHLO, HELO, NOOP, RSET or QUIT as per RFC 4954. Ignored if AuthHandler is not configured.
+	Handler      Handler
+	HandlerRcpt  HandlerRcpt
+	Hostname     string
+	LogRead      LogFunc
+	LogWrite     LogFunc
+	MaxSize      int // Maximum message size allowed, in bytes
+	Timeout      time.Duration
+	TLSConfig    *tls.Config
+	TLSListener  bool // Listen for incoming TLS connections only (not recommended as it may reduce compatibility). Ignored if TLS is not configured.
+	TLSRequired  bool // Require TLS for every command except NOOP, EHLO, STARTTLS, or QUIT as per RFC 3207. Ignored if TLS is not configured.
+}
+
+// ConfigureTLS creates a TLS configuration from certificate and key files.
+func (srv *Server) ConfigureTLS(certFile string, keyFile string) error {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+	srv.TLSConfig = &tls.Config{Certificates: []tls.Certificate{cert}}
+	return nil
+}
+
+// ConfigureTLSWithPassphrase creates a TLS configuration from a certificate,
+// an encrypted key file and the associated passphrase:
+func (srv *Server) ConfigureTLSWithPassphrase(
+	certFile string,
+	keyFile string,
+	passphrase string,
+) error {
+	certPEMBlock, err := ioutil.ReadFile(certFile)
+	if err != nil {
+		return err
+	}
+	keyPEMBlock, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return err
+	}
+	keyDERBlock, _ := pem.Decode(keyPEMBlock)
+	keyPEMDecrypted, err := x509.DecryptPEMBlock(keyDERBlock, []byte(passphrase))
+	if err != nil {
+		return err
+	}
+	var pemBlock pem.Block
+	pemBlock.Type = keyDERBlock.Type
+	pemBlock.Bytes = keyPEMDecrypted
+	keyPEMBlock = pem.EncodeToMemory(&pemBlock)
+	cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+	if err != nil {
+		return err
+	}
+	srv.TLSConfig = &tls.Config{Certificates: []tls.Certificate{cert}}
+	return nil
+}
+
+// ListenAndServe listens on the TCP network address srv.Addr and then
+// calls Serve to handle requests on incoming connections.  If
+// srv.Addr is blank, ":25" is used.
+func (srv *Server) ListenAndServe() error {
+	if srv.Addr == "" {
+		srv.Addr = ":25"
+	}
+	if srv.Appname == "" {
+		srv.Appname = "smtpd"
+	}
+	if srv.Hostname == "" {
+		srv.Hostname, _ = os.Hostname()
+	}
+	if srv.Timeout == 0 {
+		srv.Timeout = 5 * time.Minute
+	}
+
+	var ln net.Listener
+	var err error
+
+	// If TLSListener is enabled, listen for TLS connections only.
+	if srv.TLSConfig != nil && srv.TLSListener {
+		ln, err = tls.Listen("tcp", srv.Addr, srv.TLSConfig)
+	} else {
+		ln, err = net.Listen("tcp", srv.Addr)
+	}
+	if err != nil {
+		return err
+	}
+	return srv.Serve(ln)
+}
+
+// Serve creates a new SMTP session after a network connection is established.
+func (srv *Server) Serve(ln net.Listener) error {
+	defer ln.Close()
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
+				continue
+			}
+			return err
+		}
+		session := srv.newSession(conn)
+		go session.serve()
+	}
+}
+
+type session struct {
+	srv           *Server
+	conn          net.Conn
+	br            *bufio.Reader
+	bw            *bufio.Writer
+	remoteIP      string // Remote IP address
+	remoteHost    string // Remote hostname according to reverse DNS lookup
+	remoteName    string // Remote hostname as supplied with EHLO
+	tls           bool
+	authenticated bool
+}
+
+// Create new session from connection.
+func (srv *Server) newSession(conn net.Conn) (s *session) {
+	s = &session{
+		srv:  srv,
+		conn: conn,
+		br:   bufio.NewReader(conn),
+		bw:   bufio.NewWriter(conn),
+	}
+
+	// Get remote end info for the Received header.
+	s.remoteIP, _, _ = net.SplitHostPort(s.conn.RemoteAddr().String())
+	names, err := net.LookupAddr(s.remoteIP)
+	if err == nil && len(names) > 0 {
+		s.remoteHost = names[0]
+	} else {
+		s.remoteHost = "unknown"
+	}
+
+	// Set tls = true if TLS is already in use.
+	_, s.tls = s.conn.(*tls.Conn)
+
+	return
+}
+
+// Function called to handle connection requests.
+func (s *session) serve() {
+	defer s.conn.Close()
+	var from string
+	var gotFrom bool
+	var to []string
+	var buffer bytes.Buffer
+
+	// Send banner.
+	s.writef("220 %s %s ESMTP Service ready", s.srv.Hostname, s.srv.Appname)
+
+loop:
+	for {
+		// Attempt to read a line from the socket.
+		// On timeout, send a timeout message and return from serve().
+		// On error, assume the client has gone away i.e. return from serve().
+		line, err := s.readLine()
+		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				s.writef("421 4.4.2 %s %s ESMTP Service closing transmission channel after timeout exceeded", s.srv.Hostname, s.srv.Appname)
+			}
+			break
+		}
+		verb, args := s.parseLine(line)
+
+		switch verb {
+		case "HELO":
+			s.remoteName = args
+			s.writef("250 %s greets %s", s.srv.Hostname, s.remoteName)
+
+			// RFC 2821 section 4.1.4 specifies that EHLO has the same effect as RSET, so reset for HELO too.
+			from = ""
+			gotFrom = false
+			to = nil
+			buffer.Reset()
+		case "EHLO":
+			s.remoteName = args
+			s.writef(s.makeEHLOResponse())
+
+			// RFC 2821 section 4.1.4 specifies that EHLO has the same effect as RSET.
+			from = ""
+			gotFrom = false
+			to = nil
+			buffer.Reset()
+		case "MAIL":
+			if s.srv.TLSConfig != nil && s.srv.TLSRequired && !s.tls {
+				s.writef("530 5.7.0 Must issue a STARTTLS command first")
+				break
+			}
+			if s.srv.AuthHandler != nil && s.srv.AuthRequired && !s.authenticated {
+				s.writef("530 5.7.0 Authentication required")
+				break
+			}
+
+			match := mailFromRE.FindStringSubmatch(args)
+			if match == nil {
+				s.writef("501 5.5.4 Syntax error in parameters or arguments (invalid FROM parameter)")
+			} else {
+				// Handle optional parameters after FROM.
+				var sizeParam string
+				var invalid bool
+				if len(match[2]) > 0 {
+					params := strings.Fields(match[3])
+					for _, p := range params {
+						up := strings.ToUpper(p)
+						switch {
+						case strings.HasPrefix(up, "SIZE="):
+							sizeParam = p[len("SIZE="):]
+						case up == "SMTPUTF8":
+							// supported but ignored
+						default:
+							invalid = true
+						}
+					}
+				}
+
+				if invalid {
+					s.writef("501 5.5.4 Syntax error in parameters or arguments (invalid parameter)")
+				} else if sizeParam != "" {
+					size, err := strconv.Atoi(sizeParam)
+					if err != nil {
+						s.writef("501 5.5.4 Syntax error in parameters or arguments (invalid SIZE parameter)")
+					} else if s.srv.MaxSize > 0 && size > s.srv.MaxSize {
+						err = maxSizeExceeded(s.srv.MaxSize)
+						s.writef(err.Error())
+					} else {
+						from = match[1]
+						gotFrom = true
+						s.writef("250 2.1.0 Ok")
+					}
+				} else {
+					from = match[1]
+					gotFrom = true
+					s.writef("250 2.1.0 Ok")
+				}
+			}
+			to = nil
+			buffer.Reset()
+		case "RCPT":
+			if s.srv.TLSConfig != nil && s.srv.TLSRequired && !s.tls {
+				s.writef("530 5.7.0 Must issue a STARTTLS command first")
+				break
+			}
+			if s.srv.AuthHandler != nil && s.srv.AuthRequired && !s.authenticated {
+				s.writef("530 5.7.0 Authentication required")
+				break
+			}
+			if !gotFrom {
+				s.writef("503 5.5.1 Bad sequence of commands (MAIL required before RCPT)")
+				break
+			}
+
+			match := rcptToRE.FindStringSubmatch(args)
+			if match == nil {
+				s.writef("501 5.5.4 Syntax error in parameters or arguments (invalid TO parameter)")
+			} else {
+				// RFC 5321 specifies 100 minimum recipients
+				if len(to) == 100 {
+					s.writef("452 4.5.3 Too many recipients")
+				} else {
+					accept := true
+					if s.srv.HandlerRcpt != nil {
+						accept = s.srv.HandlerRcpt(s.conn.RemoteAddr(), from, match[1])
+					}
+					if accept {
+						to = append(to, match[1])
+						s.writef("250 2.1.5 Ok")
+					} else {
+						s.writef("550 5.1.0 Requested action not taken: mailbox unavailable")
+					}
+				}
+			}
+		case "DATA":
+			if s.srv.TLSConfig != nil && s.srv.TLSRequired && !s.tls {
+				s.writef("530 5.7.0 Must issue a STARTTLS command first")
+				break
+			}
+			if s.srv.AuthHandler != nil && s.srv.AuthRequired && !s.authenticated {
+				s.writef("530 5.7.0 Authentication required")
+				break
+			}
+			if !gotFrom || len(to) == 0 {
+				s.writef("503 5.5.1 Bad sequence of commands (MAIL & RCPT required before DATA)")
+				break
+			}
+
+			s.writef("354 Start mail input; end with <CR><LF>.<CR><LF>")
+
+			// Attempt to read message body from the socket.
+			// On timeout, send a timeout message and return from serve().
+			// On net.Error, assume the client has gone away i.e. return from serve().
+			// On other errors, allow the client to try again.
+			data, err := s.readData()
+			if err != nil {
+				switch err.(type) {
+				case net.Error:
+					if err.(net.Error).Timeout() {
+						s.writef("421 4.4.2 %s %s ESMTP Service closing transmission channel after timeout exceeded", s.srv.Hostname, s.srv.Appname)
+					}
+					break loop
+				case maxSizeExceededError:
+					s.writef(err.Error())
+					continue
+				default:
+					s.writef("451 4.3.0 Requested action aborted: local error in processing")
+					continue
+				}
+			}
+
+			// Create Received header & write message body into buffer.
+			buffer.Reset()
+			buffer.Write(s.makeHeaders(to))
+			buffer.Write(data)
+
+			// Pass mail on to handler.
+			if s.srv.Handler != nil {
+				err := s.srv.Handler(s.conn.RemoteAddr(), from, to, buffer.Bytes())
+				if err != nil {
+					s.writef("451 4.3.5 Unable to process mail")
+					break
+				}
+			}
+			s.writef("250 2.0.0 Ok: queued")
+
+			// Reset for next mail.
+			from = ""
+			gotFrom = false
+			to = nil
+			buffer.Reset()
+		case "QUIT":
+			s.writef("221 2.0.0 %s %s ESMTP Service closing transmission channel", s.srv.Hostname, s.srv.Appname)
+			break loop
+		case "RSET":
+			if s.srv.TLSConfig != nil && s.srv.TLSRequired && !s.tls {
+				s.writef("530 5.7.0 Must issue a STARTTLS command first")
+				break
+			}
+			s.writef("250 2.0.0 Ok")
+			from = ""
+			gotFrom = false
+			to = nil
+			buffer.Reset()
+		case "NOOP":
+			s.writef("250 2.0.0 Ok")
+		case "HELP", "VRFY", "EXPN":
+			// See RFC 5321 section 4.2.4 for usage of 500 & 502 response codes.
+			s.writef("502 5.5.1 Command not implemented")
+		case "STARTTLS":
+			// Parameters are not allowed (RFC 3207 section 4).
+			if args != "" {
+				s.writef("501 5.5.2 Syntax error (no parameters allowed)")
+				break
+			}
+
+			// Handle case where TLS is requested but not configured (and therefore not listed as a service extension).
+			if s.srv.TLSConfig == nil {
+				s.writef("502 5.5.1 Command not implemented")
+				break
+			}
+
+			// Handle case where STARTTLS is received when TLS is already in use.
+			if s.tls {
+				s.writef("503 5.5.1 Bad sequence of commands (TLS already in use)")
+				break
+			}
+
+			s.writef("220 2.0.0 Ready to start TLS")
+
+			// Establish a TLS connection with the client.
+			tlsConn := tls.Server(s.conn, s.srv.TLSConfig)
+			err := tlsConn.Handshake()
+			if err != nil {
+				s.writef("403 4.7.0 TLS handshake failed")
+				break
+			}
+
+			// TLS handshake succeeded, switch to using the TLS connection.
+			s.conn = tlsConn
+			s.br = bufio.NewReader(s.conn)
+			s.bw = bufio.NewWriter(s.conn)
+			s.tls = true
+
+			// RFC 3207 specifies that the server must discard any prior knowledge obtained from the client.
+			s.remoteName = ""
+			from = ""
+			gotFrom = false
+			to = nil
+			buffer.Reset()
+		case "AUTH":
+			if s.srv.TLSConfig != nil && s.srv.TLSRequired && !s.tls {
+				s.writef("530 5.7.0 Must issue a STARTTLS command first")
+				break
+			}
+			// Handle case where AUTH is requested but not configured (and therefore not listed as a service extension).
+			if s.srv.AuthHandler == nil {
+				s.writef("502 5.5.1 Command not implemented")
+				break
+			}
+
+			// Handle case where AUTH is received when already authenticated.
+			if s.authenticated {
+				s.writef("503 5.5.1 Bad sequence of commands (already authenticated for this session)")
+				break
+			}
+
+			// RFC 4954 specifies that AUTH is not permitted during mail transactions.
+			if gotFrom || len(to) > 0 {
+				s.writef("503 5.5.1 Bad sequence of commands (AUTH not permitted during mail transaction)")
+				break
+			}
+
+			// RFC 4954 requires a mechanism parameter.
+			authType, authArgs := s.parseLine(args)
+			if authType == "" {
+				s.writef("501 5.5.4 Malformed AUTH input (argument required)")
+				break
+			}
+
+			// RFC 4954 requires rejecting unsupported authentication mechanisms with a 504 response.
+			allowedAuth := s.authMechs()
+			if allowed, found := allowedAuth[authType]; !found || !allowed {
+				s.writef("504 5.5.4 Unrecognized authentication type")
+				break
+			}
+
+			// RFC 4954 also specifies that ESMTP code 5.5.4 ("Invalid command arguments") should be returned
+			// when attempting to use an unsupported authentication type.
+			// Many servers return 5.7.4 ("Security features not supported") instead.
+			switch authType {
+			case "PLAIN":
+				s.authenticated, err = s.handleAuthPlain(authArgs)
+			case "LOGIN":
+				s.authenticated, err = s.handleAuthLogin(authArgs)
+			case "CRAM-MD5":
+				s.authenticated, err = s.handleAuthCramMD5()
+			}
+
+			if err != nil {
+				if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+					s.writef("421 4.4.2 %s %s ESMTP Service closing transmission channel after timeout exceeded", s.srv.Hostname, s.srv.Appname)
+					break loop
+				}
+
+				s.writef(err.Error())
+				break
+			}
+
+			if s.authenticated {
+				s.writef("235 2.7.0 Authentication successful")
+			} else {
+				s.writef("535 5.7.8 Authentication credentials invalid")
+			}
+		default:
+			// See RFC 5321 section 4.2.4 for usage of 500 & 502 response codes.
+			s.writef("500 5.5.2 Syntax error, command unrecognized")
+		}
+	}
+}
+
+// Wrapper function for writing a complete line to the socket.
+func (s *session) writef(format string, args ...interface{}) error {
+	if s.srv.Timeout > 0 {
+		s.conn.SetWriteDeadline(time.Now().Add(s.srv.Timeout))
+	}
+
+	line := fmt.Sprintf(format, args...)
+	fmt.Fprintf(s.bw, line+"\r\n")
+	err := s.bw.Flush()
+
+	if Debug {
+		verb := "WROTE"
+		if s.srv.LogWrite != nil {
+			s.srv.LogWrite(s.remoteIP, verb, line)
+		} else {
+			log.Println(s.remoteIP, verb, line)
+		}
+	}
+
+	return err
+}
+
+// Read a complete line from the socket.
+func (s *session) readLine() (string, error) {
+	if s.srv.Timeout > 0 {
+		s.conn.SetReadDeadline(time.Now().Add(s.srv.Timeout))
+	}
+
+	line, err := s.br.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	line = strings.TrimSpace(line) // Strip trailing \r\n
+
+	if Debug {
+		verb := "READ"
+		if s.srv.LogRead != nil {
+			s.srv.LogRead(s.remoteIP, verb, line)
+		} else {
+			log.Println(s.remoteIP, verb, line)
+		}
+	}
+
+	return line, err
+}
+
+// Parse a line read from the socket.
+func (s *session) parseLine(line string) (verb string, args string) {
+	if idx := strings.Index(line, " "); idx != -1 {
+		verb = strings.ToUpper(line[:idx])
+		args = strings.TrimSpace(line[idx+1:])
+	} else {
+		verb = strings.ToUpper(line)
+		args = ""
+	}
+	return verb, args
+}
+
+// Read the message data following a DATA command.
+func (s *session) readData() ([]byte, error) {
+	var data []byte
+	for {
+		if s.srv.Timeout > 0 {
+			s.conn.SetReadDeadline(time.Now().Add(s.srv.Timeout))
+		}
+
+		line, err := s.br.ReadBytes('\n')
+		if err != nil {
+			return nil, err
+		}
+		// Handle end of data denoted by lone period (\r\n.\r\n)
+		if bytes.Equal(line, []byte(".\r\n")) {
+			break
+		}
+		// Remove leading period (RFC 5321 section 4.5.2)
+		if line[0] == '.' {
+			line = line[1:]
+		}
+
+		// Enforce the maximum message size limit.
+		if s.srv.MaxSize > 0 {
+			if len(data)+len(line) > s.srv.MaxSize {
+				_, _ = s.br.Discard(s.br.Buffered()) // Discard the buffer remnants.
+				return nil, maxSizeExceeded(s.srv.MaxSize)
+			}
+		}
+
+		data = append(data, line...)
+	}
+	return data, nil
+}
+
+// Create the Received header to comply with RFC 2821 section 3.8.2.
+// TODO: Work out what to do with multiple to addresses.
+func (s *session) makeHeaders(to []string) []byte {
+	var buffer bytes.Buffer
+	now := time.Now().Format("Mon, _2 Jan 2006 15:04:05 -0700 (MST)")
+	buffer.WriteString(fmt.Sprintf("Received: from %s (%s [%s])\r\n", s.remoteName, s.remoteHost, s.remoteIP))
+	buffer.WriteString(fmt.Sprintf("        by %s (%s) with SMTP\r\n", s.srv.Hostname, s.srv.Appname))
+	buffer.WriteString(fmt.Sprintf("        for <%s>; %s\r\n", to[0], now))
+	return buffer.Bytes()
+}
+
+// Determine allowed authentication mechanisms.
+// RFC 4954 specifies that plaintext authentication mechanisms such as LOGIN and PLAIN require a TLS connection.
+// This can be explicitly overridden e.g. setting s.srv.AuthMechs["LOGIN"] = true.
+func (s *session) authMechs() (mechs map[string]bool) {
+	mechs = map[string]bool{"LOGIN": s.tls, "PLAIN": s.tls, "CRAM-MD5": true}
+
+	for mech := range mechs {
+		allowed, found := s.srv.AuthMechs[mech]
+		if found {
+			mechs[mech] = allowed
+		}
+	}
+
+	return
+}
+
+// Create the greeting string sent in response to an EHLO command.
+func (s *session) makeEHLOResponse() (response string) {
+	response = fmt.Sprintf("250-%s greets %s\r\n", s.srv.Hostname, s.remoteName)
+
+	// RFC 1870 specifies that "SIZE 0" indicates no maximum size is in force.
+	response += fmt.Sprintf("250-SIZE %d\r\n", s.srv.MaxSize)
+
+	// Only list STARTTLS if TLS is configured, but not currently in use.
+	if s.srv.TLSConfig != nil && !s.tls {
+		response += "250-STARTTLS\r\n"
+	}
+
+	// Only list AUTH if an AuthHandler is configured and at least one mechanism is allowed.
+	if s.srv.AuthHandler != nil {
+		var mechs []string
+		for mech, allowed := range s.authMechs() {
+			if allowed {
+				mechs = append(mechs, mech)
+			}
+		}
+		if len(mechs) > 0 {
+			response += "250-AUTH " + strings.Join(mechs, " ") + "\r\n"
+		}
+	}
+
+	// Advertise SMTPUTF8 support for internationalized local-parts.
+	response += "250-SMTPUTF8\r\n"
+
+	response += "250 ENHANCEDSTATUSCODES"
+	return
+}
+
+func (s *session) handleAuthLogin(arg string) (bool, error) {
+	var err error
+
+	if arg == "" {
+		s.writef("334 " + base64.StdEncoding.EncodeToString([]byte("Username:")))
+		arg, err = s.readLine()
+		if err != nil {
+			return false, err
+		}
+	}
+
+	username, err := base64.StdEncoding.DecodeString(arg)
+	if err != nil {
+		return false, errors.New("501 5.5.2 Syntax error (unable to decode)")
+	}
+
+	s.writef("334 " + base64.StdEncoding.EncodeToString([]byte("Password:")))
+	line, err := s.readLine()
+	if err != nil {
+		return false, err
+	}
+
+	password, err := base64.StdEncoding.DecodeString(line)
+	if err != nil {
+		return false, errors.New("501 5.5.2 Syntax error (unable to decode)")
+	}
+
+	// Validate credentials.
+	authenticated, err := s.srv.AuthHandler(s.conn.RemoteAddr(), "LOGIN", username, password, nil)
+
+	return authenticated, err
+}
+
+func (s *session) handleAuthPlain(arg string) (bool, error) {
+	var err error
+
+	// If fast mode (AUTH PLAIN [arg]) is not used, prompt for credentials.
+	if arg == "" {
+		s.writef("334 ")
+		arg, err = s.readLine()
+		if err != nil {
+			return false, err
+		}
+	}
+
+	data, err := base64.StdEncoding.DecodeString(arg)
+	if err != nil {
+		return false, errors.New("501 5.5.2 Syntax error (unable to decode)")
+	}
+
+	parts := bytes.Split(data, []byte{0})
+	if len(parts) != 3 {
+		return false, errors.New("501 5.5.2 Syntax error (unable to parse)")
+	}
+
+	// Validate credentials.
+	authenticated, err := s.srv.AuthHandler(s.conn.RemoteAddr(), "PLAIN", parts[1], parts[2], nil)
+
+	return authenticated, err
+}
+
+func (s *session) handleAuthCramMD5() (bool, error) {
+	shared := "<" + strconv.Itoa(os.Getpid()) + "." + strconv.Itoa(time.Now().Nanosecond()) + "@" + s.srv.Hostname + ">"
+
+	s.writef("334 " + base64.StdEncoding.EncodeToString([]byte(shared)))
+
+	data, err := s.readLine()
+	if err != nil {
+		return false, err
+	}
+
+	if data == "*" {
+		return false, errors.New("501 5.7.0 Authentication cancelled")
+	}
+
+	buf, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return false, errors.New("501 5.5.2 Syntax error (unable to decode)")
+	}
+
+	fields := strings.Split(string(buf), " ")
+	if len(fields) < 2 {
+		return false, errors.New("501 5.5.2 Syntax error (unable to parse)")
+	}
+
+	// Validate credentials.
+	authenticated, err := s.srv.AuthHandler(s.conn.RemoteAddr(), "CRAM-MD5", []byte(fields[0]), []byte(fields[1]), []byte(shared))
+
+	return authenticated, err
+}

--- a/internal/smtpd/smtpd_test.go
+++ b/internal/smtpd/smtpd_test.go
@@ -1,0 +1,1560 @@
+package smtpd
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+var cert = makeCertificate()
+
+// Create a client to run commands with. Parse the banner for 220 response.
+func newConn(t *testing.T, server *Server) net.Conn {
+	clientConn, serverConn := net.Pipe()
+	session := server.newSession(serverConn)
+	go session.serve()
+
+	banner, err := bufio.NewReader(clientConn).ReadString('\n')
+	if err != nil {
+		t.Fatalf("Failed to read banner from test server: %v", err)
+	}
+	if banner[0:3] != "220" {
+		t.Fatalf("Read incorrect banner from test server: %v", banner)
+	}
+	return clientConn
+}
+
+// Send a command and verify the 3 digit code from the response.
+func cmdCode(t *testing.T, conn net.Conn, cmd string, code string) string {
+	fmt.Fprintf(conn, "%s\r\n", cmd)
+	resp, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		t.Fatalf("Failed to read response from test server: %v", err)
+	}
+	if resp[0:3] != code {
+		t.Errorf("Command \"%s\" response code is %s, want %s", cmd, resp[0:3], code)
+	}
+	return strings.TrimSpace(resp)
+}
+
+// Simple tests: connect, send command, then send QUIT.
+// RFC 2821 section 4.1.4 specifies that these commands do not require a prior EHLO,
+// only that clients should send one, so test without EHLO.
+func TestSimpleCommands(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		code string
+	}{
+		{"NOOP", "250"},
+		{"RSET", "250"},
+		{"HELP", "502"},
+		{"VRFY", "502"},
+		{"EXPN", "502"},
+		{"TEST", "500"}, // Unsupported command
+		{"", "500"},     // Blank command
+	}
+
+	for _, tt := range tests {
+		conn := newConn(t, &Server{})
+		cmdCode(t, conn, tt.cmd, tt.code)
+		cmdCode(t, conn, "QUIT", "221")
+		conn.Close()
+	}
+}
+
+func TestCmdHELO(t *testing.T) {
+	conn := newConn(t, &Server{})
+
+	// Send HELO, expect greeting.
+	cmdCode(t, conn, "HELO host.example.com", "250")
+
+	// Verify that HELO resets the current transaction state like RSET.
+	// RFC 2821 section 4.1.4 says EHLO should cause a reset, so verify that HELO does it too.
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "HELO host.example.com", "250")
+	cmdCode(t, conn, "DATA", "503")
+
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdEHLO(t *testing.T) {
+	conn := newConn(t, &Server{})
+
+	// Send EHLO, expect greeting.
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// Verify that EHLO resets the current transaction state like RSET.
+	// See RFC 2821 section 4.1.4 for more detail.
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+	cmdCode(t, conn, "DATA", "503")
+
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdRSET(t *testing.T) {
+	conn := newConn(t, &Server{})
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// Verify that RSET clears the current transaction state.
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "RSET", "250")
+	cmdCode(t, conn, "DATA", "503")
+
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdMAIL(t *testing.T) {
+	conn := newConn(t, &Server{})
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// MAIL with no FROM arg should return 501 syntax error
+	cmdCode(t, conn, "MAIL", "501")
+	// MAIL with empty FROM arg should return 501 syntax error
+	cmdCode(t, conn, "MAIL FROM:", "501")
+	cmdCode(t, conn, "MAIL FROM: ", "501")
+	cmdCode(t, conn, "MAIL FROM:  ", "501")
+	// MAIL with DSN-style FROM arg should return 250 Ok
+	cmdCode(t, conn, "MAIL FROM:<>", "250")
+	// MAIL with valid FROM arg should return 250 Ok
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+
+	// MAIL with seemingly valid but noncompliant FROM arg (single space after the colon) should be tolerated and should return 250 Ok
+	cmdCode(t, conn, "MAIL FROM: <sender@example.com>", "250")
+	// MAIL with seemingly valid but noncompliant FROM arg (double space after the colon) should return 501 syntax error
+	cmdCode(t, conn, "MAIL FROM:  <sender@example.com>", "501")
+
+	// MAIL with valid SIZE parameter should return 250 Ok
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com> SIZE=1000", "250")
+
+	// MAIL with bad size parameter should return 501 syntax error
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com> SIZE", "501")
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com> SIZE=", "501")
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com> SIZE= ", "501")
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com> SIZE=foo", "501")
+
+	// TODO: MAIL with valid AUTH parameter should return 250 Ok
+
+	// TODO: MAIL with invalid AUTH parameter must return 501 syntax error
+
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdMAILMaxSize(t *testing.T) {
+	maxSize := 10 + time.Now().Minute()
+	conn := newConn(t, &Server{MaxSize: maxSize})
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// MAIL with no size parameter should return 250 Ok
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+
+	// MAIL with bad size parameter should return 501 syntax error
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com> SIZE", "501")
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com> SIZE=", "501")
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com> SIZE= ", "501")
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com> SIZE=foo", "501")
+
+	// MAIL with size parameter zero should return 250 Ok
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com> SIZE=0", "250")
+
+	// MAIL below the maximum size should return 250 Ok
+	cmdCode(t, conn, fmt.Sprintf("MAIL FROM:<sender@example.com> SIZE=%d", maxSize-1), "250")
+
+	// MAIL matching the maximum size should return 250 Ok
+	cmdCode(t, conn, fmt.Sprintf("MAIL FROM:<sender@example.com> SIZE=%d", maxSize), "250")
+
+	// MAIL above the maximum size should return a maximum size exceeded error.
+	cmdCode(t, conn, fmt.Sprintf("MAIL FROM:<sender@example.com> SIZE=%d", maxSize+1), "552")
+
+	// Clients should send either RSET or QUIT after receiving 552 (RFC 1870 section 6.2).
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdRCPT(t *testing.T) {
+	conn := newConn(t, &Server{})
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// RCPT without prior MAIL should return 503 bad sequence
+	cmdCode(t, conn, "RCPT", "503")
+
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+
+	// RCPT with no TO arg should return 501 syntax error
+	cmdCode(t, conn, "RCPT", "501")
+
+	// RCPT with empty TO arg should return 501 syntax error
+	cmdCode(t, conn, "RCPT TO:", "501")
+	cmdCode(t, conn, "RCPT TO: ", "501")
+	cmdCode(t, conn, "RCPT TO:  ", "501")
+
+	// RCPT with valid TO arg should return 250 Ok
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+
+	// Up to 100 valid recipients should return 250 Ok
+	for i := 2; i < 101; i++ {
+		cmdCode(t, conn, fmt.Sprintf("RCPT TO:<recipient%v@example.com>", i), "250")
+	}
+
+	// 101st valid recipient with valid TO arg should return 452 too many recipients
+	cmdCode(t, conn, "RCPT TO:<recipient101@example.com>", "452")
+
+	// RCPT with valid TO arg and prior DSN-style FROM arg should return 250 Ok
+	cmdCode(t, conn, "RSET", "250")
+	cmdCode(t, conn, "MAIL FROM:<>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+
+	// RCPT with seemingly valid but noncompliant TO arg (single space after the colon) should be tolerated and should return 250 Ok
+	cmdCode(t, conn, "RSET", "250")
+	cmdCode(t, conn, "MAIL FROM:<>", "250")
+	cmdCode(t, conn, "RCPT TO: <recipient@example.com>", "250")
+
+	// RCPT with seemingly valid but noncompliant TO arg (double space after the colon) should return 501 syntax error
+	cmdCode(t, conn, "RSET", "250")
+	cmdCode(t, conn, "MAIL FROM:<>", "250")
+	cmdCode(t, conn, "RCPT TO:  <recipient@example.com>", "501")
+
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdDATA(t *testing.T) {
+	conn := newConn(t, &Server{})
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// DATA without prior MAIL & RCPT should return 503 bad sequence
+	cmdCode(t, conn, "DATA", "503")
+	cmdCode(t, conn, "RSET", "250")
+
+	// DATA without prior RCPT should return 503 bad sequence
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "DATA", "503")
+	cmdCode(t, conn, "RSET", "250")
+
+	// Test a full mail transaction.
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "DATA", "354")
+	cmdCode(t, conn, "Test message.\r\n.", "250")
+
+	// Test a full mail transaction with a bad last recipient.
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:", "501")
+	cmdCode(t, conn, "DATA", "354")
+	cmdCode(t, conn, "Test message.\r\n.", "250")
+
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdDATAWithMaxSize(t *testing.T) {
+	// "Test message.\r\n." is 15 bytes after trailing period is removed.
+	conn := newConn(t, &Server{MaxSize: 15})
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// Messages below the maximum size should return 250 Ok
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "DATA", "354")
+	cmdCode(t, conn, "Test message\r\n.", "250")
+
+	// Messages matching the maximum size should return 250 Ok
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "DATA", "354")
+	cmdCode(t, conn, "Test message.\r\n.", "250")
+
+	// Messages above the maximum size should return a maximum size exceeded error.
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "DATA", "354")
+	cmdCode(t, conn, "Test message that is too long.\r\n.", "552")
+
+	// Clients should send either RSET or QUIT after receiving 552 (RFC 1870 section 6.2).
+	cmdCode(t, conn, "RSET", "250")
+
+	// Messages above the maximum size should return a maximum size exceeded error.
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "DATA", "354")
+	cmdCode(t, conn, "Test message.\r\nSecond line that is too long.\r\n.", "552")
+
+	// Clients should send either RSET or QUIT after receiving 552 (RFC 1870 section 6.2).
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+type mockHandler struct {
+	handlerCalled int
+}
+
+func (m *mockHandler) handler(err error) func(a net.Addr, f string, t []string, d []byte) error {
+	return func(a net.Addr, f string, t []string, d []byte) error {
+		m.handlerCalled++
+		return err
+	}
+}
+
+func TestCmdDATAWithHandler(t *testing.T) {
+	m := mockHandler{}
+	conn := newConn(t, &Server{Handler: m.handler(nil)})
+
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "DATA", "354")
+	cmdCode(t, conn, "Test message.\r\n.", "250")
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+
+	if m.handlerCalled != 1 {
+		t.Errorf("MailHandler called %d times, want one call", m.handlerCalled)
+	}
+}
+
+func TestCmdDATAWithHandlerError(t *testing.T) {
+	m := mockHandler{}
+	conn := newConn(t, &Server{Handler: m.handler(errors.New("Handler error"))})
+
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "DATA", "354")
+	cmdCode(t, conn, "Test message.\r\n.", "451")
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+
+	if m.handlerCalled != 1 {
+		t.Errorf("MailHandler called %d times, want one call", m.handlerCalled)
+	}
+}
+
+func TestCmdSTARTTLS(t *testing.T) {
+	conn := newConn(t, &Server{})
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// By default, TLS is not configured, so STARTTLS should return 502 not implemented.
+	cmdCode(t, conn, "STARTTLS", "502")
+
+	// Parameters are not allowed (RFC 3207 section 4).
+	cmdCode(t, conn, "STARTTLS FOO", "501")
+
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdSTARTTLSFailure(t *testing.T) {
+	// Deliberately misconfigure TLS to force a handshake failure.
+	server := &Server{TLSConfig: &tls.Config{}}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// When TLS is configured, STARTTLS should return 220 Ready to start TLS.
+	cmdCode(t, conn, "STARTTLS", "220")
+
+	// A failed TLS handshake should return 403 TLS handshake failed
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	err := tlsConn.Handshake()
+	if err != nil {
+		reader := bufio.NewReader(conn)
+		resp, readErr := reader.ReadString('\n')
+		if readErr != nil {
+			t.Fatalf("Failed to read response after failed TLS handshake: %v", err)
+		}
+		if resp[0:3] != "403" {
+			t.Errorf("Failed TLS handshake response code is %s, want 403", resp[0:3])
+		}
+	} else {
+		t.Error("TLS handshake succeeded with empty tls.Config, want failure")
+	}
+
+	cmdCode(t, conn, "QUIT", "221")
+	tlsConn.Close()
+}
+
+// Utility function to make a valid TLS certificate for use by the server.
+func makeCertificate() tls.Certificate {
+	const certPEM = `
+-----BEGIN CERTIFICATE-----
+MIID9DCCAtygAwIBAgIJAIX/1sxuqZKrMA0GCSqGSIb3DQEBCwUAMFkxCzAJBgNV
+BAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBX
+aWRnaXRzIFB0eSBMdGQxEjAQBgNVBAMTCWxvY2FsaG9zdDAeFw0xNzA1MDYxNDIy
+MjVaFw0yNzA1MDQxNDIyMjVaMFkxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21l
+LVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxEjAQBgNV
+BAMTCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALO4
+XVY5Kw9eNblqBenC03Wz6qemLFw8zLDNrehvjYuJPn5WVwvzLNP+3S02iqQD+Y1k
+vszqDIZLQdjWLiEZdtxfemyIr+RePIMclnceGYFx3Zgg5qeyvOWlJLM41ZU8YZb/
+zGj3RtXzuOZ5vePSLGS1nudjrKSBs7shRY8bYjkOqFujsSVnEK7s3Kb2Sf/rO+7N
+RZ1df3hhyKtyq4Pb5eC1mtQqcRjRSZdTxva8kO4vRQbvGgjLUakvBVrrnwbww5a4
+2wKbQPKIClEbSLyKQ62zR8gW1rPwBdokd8u9+rLbcmr7l0OuAsSn5Xi9x6VxXTNE
+bgCa1KVoE4bpoGG+KQsCAwEAAaOBvjCBuzAdBgNVHQ4EFgQUILso/fozIhaoyi05
+XNSWzP/ck+4wgYsGA1UdIwSBgzCBgIAUILso/fozIhaoyi05XNSWzP/ck+6hXaRb
+MFkxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJ
+bnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxEjAQBgNVBAMTCWxvY2FsaG9zdIIJAIX/
+1sxuqZKrMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEBAIbzsvTZb8LA
+JqyaTttsMMA1szf4WBX88lVWbIk91k0nlTa0BiU/UocKrU6c9PySwJ6FOFJpgpdH
+z/kmJ+S+d4pvgqBzWbKMoMrNlMt6vL+H8Mbf/l/CN91eNM+gJZu2HgBIFGW1y4Wy
+gOzjEm9bw15Hgqqs0P4CSy7jcelWA285DJ7IG1qdPGhAKxT4/UuDin8L/u2oeYWH
+3DwTDO4kAUnKetcmNQFSX3Ge50uQypl8viYgFJ2axOfZ3imjQZrs7M1Og6Wnj/SD
+F414wVQibsZyZp8cqwR/OinvxloPkPVnf163jPRtftuqezEY8Nyj83O5u5sC1Azs
+X/Gm54QNk6w=
+-----END CERTIFICATE-----`
+	const keyPEM = `
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAs7hdVjkrD141uWoF6cLTdbPqp6YsXDzMsM2t6G+Ni4k+flZX
+C/Ms0/7dLTaKpAP5jWS+zOoMhktB2NYuIRl23F96bIiv5F48gxyWdx4ZgXHdmCDm
+p7K85aUkszjVlTxhlv/MaPdG1fO45nm949IsZLWe52OspIGzuyFFjxtiOQ6oW6Ox
+JWcQruzcpvZJ/+s77s1FnV1/eGHIq3Krg9vl4LWa1CpxGNFJl1PG9ryQ7i9FBu8a
+CMtRqS8FWuufBvDDlrjbAptA8ogKURtIvIpDrbNHyBbWs/AF2iR3y736sttyavuX
+Q64CxKfleL3HpXFdM0RuAJrUpWgThumgYb4pCwIDAQABAoIBAHzvYntJPKTvUhu2
+F6w8kvHVBABNpbLtVUJniUj3G4fv/bCn5tVY1EX/e9QtgU2psbbYXUdoQRKuiHTr
+15+M6zMhcKK4lsYDuL9QhU0DcKmq9WgHHzFfMK/YEN5CWT/ofNMSuhASLn0Xc+dM
+pHQWrGPKWk/y25Z0z/P7mjZ0y+BrJOKlxV53A2AWpj4JtjX2YO6s/eiraFX+RNlv
+GyWzeQ7Gynm2TD9VXhS+m40VVBmmbbeZYDlziDoWWNe9r26A+C8K65gZtjKdarMd
+0LN89jJvI1pUxcIuvZJnumWUenZ7JhfBGpkfAwLB+MogUo9ekAHv1IZv/m3uWq9f
+Zml2dZECgYEA2OCI8kkLRa3+IodqQNFrb/uZ16YouQ71B7nBgAxls9nuhyELKO7d
+fzf1snPx6cbaCQKTyxrlYvck4gz8P09R7nVYwJuTmP0+QIgeCCc3Y9A2dyExaC6I
+uKkFzJEqIVZNLvdjBRWQs5AiD1w58oto+wOvbagAQM483WiJ/qFaHCMCgYEA1CPo
+zwI6pCn39RSYffK25HXM1q3i8ypkYdNsG6IVqS2FqHqj8XJSnDvLeIm7W1Rtw+uM
+QdZ5O6PH31XgolG6LrFkW9vtfH+QnXQA2AnZQEfn034YZubhcexLqAkS9r0FUUZp
+a1WI2jSxBBeB+to6MdNABuQOL3NHjPUidUKnOfkCgYA+HvKbE7ka2F+23DrfHh08
+EkFat8lqWJJvCBIY73QiNAZSxnA/5UukqQ7DctqUL9U8R3S19JpH4qq55SZLrBi3
+yP0HDokUhVVTfqm7hCAlgvpW3TcdtFaNLjzu/5WlvuaU0V+XkTnFdT+MTsp6YtxL
+Kh8RtdF8vpZIhS0htm3tKQKBgQDQXoUp79KRtPdsrtIpw+GI/Xw50Yp9tkHrJLOn
+YMlN5vzFw9CMM/KYqtLsjryMtJ0sN40IjhV+UxzbbYq7ZPMvMeaVo6vdAZ+WSH8b
+tHDEBtzai5yEVntSXvrhDiimWnuCnVqmptlJG0BT+JMfRoKqtgjJu++DBARfm9hA
+vTtsYQKBgE1ttTzd3HJoIhBBSvSMbyDWTED6jecKvsVypb7QeDxZCbIwCkoK9zn1
+twPDHLBcUNhHJx6JWTR6BxI5DZoIA1tcKHtdO5smjLWNSKhXTsKWee2aNkZJkNIW
+TDHSaTMOxVUEzpx84xClf561BTiTgzQy2MULpg3AK0Cv9l0+Yrvz
+-----END RSA PRIVATE KEY-----`
+
+	cert, _ := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+	return cert
+}
+
+func TestCmdSTARTTLSSuccess(t *testing.T) {
+	// Configure a valid TLS certificate so the handshake will succeed.
+	server := &Server{TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}}}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// When TLS is configured, STARTTLS should return 220 Ready to start TLS.
+	cmdCode(t, conn, "STARTTLS", "220")
+
+	// A successful TLS handshake shouldn't return anything, it should wait for EHLO.
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	err := tlsConn.Handshake()
+	if err != nil {
+		t.Errorf("Failed to perform TLS handshake")
+	}
+
+	// The subsequent EHLO should be successful.
+	cmdCode(t, tlsConn, "EHLO host.example.com", "250")
+
+	// When TLS is already in use, STARTTLS should return 503 bad sequence.
+	cmdCode(t, tlsConn, "STARTTLS", "503")
+
+	cmdCode(t, tlsConn, "QUIT", "221")
+	tlsConn.Close()
+}
+
+func TestCmdSTARTTLSRequired(t *testing.T) {
+	tests := []struct {
+		cmd        string
+		codeBefore string
+		codeAfter  string
+	}{
+		{"EHLO host.example.com", "250", "250"},
+		{"NOOP", "250", "250"},
+		{"MAIL FROM:<sender@example.com>", "530", "250"},
+		{"RCPT TO:<recipient@example.com>", "530", "250"},
+		{"RSET", "530", "250"}, // Reset before DATA to avoid having to actually send a message.
+		{"DATA", "530", "503"},
+		{"HELP", "502", "502"},
+		{"VRFY", "502", "502"},
+		{"EXPN", "502", "502"},
+		{"TEST", "500", "500"}, // Unsupported command
+		{"", "500", "500"},     // Blank command
+		{"AUTH", "530", "502"}, // AuthHandler not configured
+	}
+
+	// If TLS is not configured, the TLSRequired setting is ignored, so it must be configured for this test.
+	server := &Server{TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}}, TLSRequired: true}
+	conn := newConn(t, server)
+
+	// If TLS is required, but not in use, reject every command except NOOP, EHLO, STARTTLS, or QUIT as per RFC 3207 section 4.
+	for _, tt := range tests {
+		cmdCode(t, conn, tt.cmd, tt.codeBefore)
+	}
+
+	// Switch to using TLS.
+	cmdCode(t, conn, "STARTTLS", "220")
+
+	// A successful TLS handshake shouldn't return anything, it should wait for EHLO.
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	err := tlsConn.Handshake()
+	if err != nil {
+		t.Errorf("Failed to perform TLS handshake")
+	}
+
+	// The subsequent EHLO should be successful.
+	cmdCode(t, tlsConn, "EHLO host.example.com", "250")
+
+	// If TLS is required, and is in use, every command should work normally.
+	for _, tt := range tests {
+		cmdCode(t, tlsConn, tt.cmd, tt.codeAfter)
+	}
+
+	cmdCode(t, tlsConn, "QUIT", "221")
+	tlsConn.Close()
+}
+
+func TestMakeHeaders(t *testing.T) {
+	now := time.Now().Format("Mon, _2 Jan 2006 15:04:05 -0700 (MST)")
+	valid := "Received: from clientName (clientHost [clientIP])\r\n" +
+		"        by serverName (smtpd) with SMTP\r\n" +
+		"        for <recipient@example.com>; " +
+		fmt.Sprintf("%s\r\n", now)
+
+	srv := &Server{Appname: "smtpd", Hostname: "serverName"}
+	s := &session{srv: srv, remoteIP: "clientIP", remoteHost: "clientHost", remoteName: "clientName"}
+	headers := s.makeHeaders([]string{"recipient@example.com"})
+	if string(headers) != valid {
+		t.Errorf("makeHeaders() returned\n%v, want\n%v", string(headers), valid)
+	}
+}
+
+// Test parsing of commands into verbs and arguments.
+func TestParseLine(t *testing.T) {
+	tests := []struct {
+		line string
+		verb string
+		args string
+	}{
+		{"EHLO host.example.com", "EHLO", "host.example.com"},
+		{"MAIL FROM:<sender@example.com>", "MAIL", "FROM:<sender@example.com>"},
+		{"RCPT TO:<recipient@example.com>", "RCPT", "TO:<recipient@example.com>"},
+		{"QUIT", "QUIT", ""},
+	}
+	s := &session{}
+	for _, tt := range tests {
+		verb, args := s.parseLine(tt.line)
+		if verb != tt.verb || args != tt.args {
+			t.Errorf("ParseLine(%v) returned %v, %v, want %v, %v", tt.line, verb, args, tt.verb, tt.args)
+		}
+	}
+}
+
+// Test reading of complete lines from the socket.
+func TestReadLine(t *testing.T) {
+	var buf bytes.Buffer
+	s := &session{}
+	s.srv = &Server{}
+	s.br = bufio.NewReader(&buf)
+
+	// Ensure readLine() returns an EOF error on an empty buffer.
+	_, err := s.readLine()
+	if err != io.EOF {
+		t.Errorf("readLine() on empty buffer returned err: %v, want EOF", err)
+	}
+
+	// Ensure trailing <CRLF> is stripped.
+	line := "FOO BAR BAZ\r\n"
+	cmd := "FOO BAR BAZ"
+	buf.Write([]byte(line))
+	output, err := s.readLine()
+	if err != nil {
+		t.Errorf("readLine(%v) returned err: %v", line, err)
+	} else if output != cmd {
+		t.Errorf("readLine(%v) returned %v, want %v", line, output, cmd)
+	}
+}
+
+// Test reading of message data, including dot stuffing (see RFC 5321 section 4.5.2).
+func TestReadData(t *testing.T) {
+	tests := []struct {
+		lines string
+		data  string
+	}{
+		// Single line message.
+		{"Test message.\r\n.\r\n", "Test message.\r\n"},
+
+		// Single line message with leading period removed.
+		{".Test message.\r\n.\r\n", "Test message.\r\n"},
+
+		// Multiple line message.
+		{"Line 1.\r\nLine 2.\r\nLine 3.\r\n.\r\n", "Line 1.\r\nLine 2.\r\nLine 3.\r\n"},
+
+		// Multiple line message with leading period removed.
+		{"Line 1.\r\n.Line 2.\r\nLine 3.\r\n.\r\n", "Line 1.\r\nLine 2.\r\nLine 3.\r\n"},
+
+		// Multiple line message with one leading period removed.
+		{"Line 1.\r\n..Line 2.\r\nLine 3.\r\n.\r\n", "Line 1.\r\n.Line 2.\r\nLine 3.\r\n"},
+	}
+	var buf bytes.Buffer
+	s := &session{}
+	s.srv = &Server{}
+	s.br = bufio.NewReader(&buf)
+
+	// Ensure readData() returns an EOF error on an empty buffer.
+	_, err := s.readData()
+	if err != io.EOF {
+		t.Errorf("readData() on empty buffer returned err: %v, want EOF", err)
+	}
+
+	for _, tt := range tests {
+		buf.Write([]byte(tt.lines))
+		data, err := s.readData()
+		if err != nil {
+			t.Errorf("readData(%v) returned err: %v", tt.lines, err)
+		} else if string(data) != tt.data {
+			t.Errorf("readData(%v) returned %v, want %v", tt.lines, string(data), tt.data)
+		}
+	}
+}
+
+// Test reading of message data with maximum size set (see RFC 1870 section 6.3).
+func TestReadDataWithMaxSize(t *testing.T) {
+	tests := []struct {
+		lines   string
+		maxSize int
+		err     error
+	}{
+		// Maximum size of zero (the default) should not return an error.
+		{"Test message.\r\n.\r\n", 0, nil},
+
+		// Messages below the maximum size should not return an error.
+		{"Test message.\r\n.\r\n", 16, nil},
+
+		// Messages matching the maximum size should not return an error.
+		{"Test message.\r\n.\r\n", 15, nil},
+
+		// Messages above the maximum size should return a maximum size exceeded error.
+		{"Test message.\r\n.\r\n", 14, maxSizeExceeded(14)},
+	}
+	var buf bytes.Buffer
+	s := &session{}
+	s.br = bufio.NewReader(&buf)
+
+	for _, tt := range tests {
+		s.srv = &Server{MaxSize: tt.maxSize}
+		buf.Write([]byte(tt.lines))
+		_, err := s.readData()
+		if err != tt.err {
+			t.Errorf("readData(%v) returned err: %v", tt.lines, tt.err)
+		}
+	}
+}
+
+// Utility function for parsing extensions listed as service extensions in response to an EHLO command.
+func parseExtensions(t *testing.T, greeting string) map[string]string {
+	extensions := make(map[string]string)
+	lines := strings.Split(greeting, "\n")
+
+	if len(lines) > 1 {
+		iLast := len(lines) - 1
+		for i, line := range lines {
+			prefix := line[0:4]
+
+			// All but the last extension code prefix should be "250-".
+			if i != iLast && prefix != "250-" {
+				t.Errorf("Extension code prefix is %s, want '250-'", prefix)
+			}
+
+			// The last extension code prefix should be "250 ".
+			if i == iLast && prefix != "250 " {
+				t.Errorf("Extension code prefix is %s, want '250 '", prefix)
+			}
+
+			// Skip greeting line.
+			if i == 0 {
+				continue
+			}
+
+			// Add line as extension.
+			line = strings.TrimSpace(line[4:]) // Strip code prefix and trailing \r\n
+			if idx := strings.Index(line, " "); idx != -1 {
+				extensions[line[:idx]] = line[idx+1:]
+			} else {
+				extensions[line] = ""
+			}
+		}
+	}
+
+	return extensions
+}
+
+// Handler function for validating authentication credentials.
+// The secret parameter is passed as nil for LOGIN and PLAIN authentication mechanisms.
+func authHandler(remoteAddr net.Addr, mechanism string, username []byte, password []byte, shared []byte) (bool, error) {
+	return string(username) == "valid", nil
+}
+
+// Test the extensions listed in response to an EHLO command.
+func TestMakeEHLOResponse(t *testing.T) {
+	s := &session{}
+	s.srv = &Server{}
+
+	// Greeting should be returned without trailing newlines.
+	greeting := s.makeEHLOResponse()
+	if len(greeting) != len(strings.TrimSpace(greeting)) {
+		t.Errorf("EHLO greeting string has leading or trailing whitespace")
+	}
+
+	// By default, TLS is not configured, so STARTTLS should not appear.
+	extensions := parseExtensions(t, s.makeEHLOResponse())
+	if _, ok := extensions["STARTTLS"]; ok {
+		t.Errorf("STARTTLS appears in the extension list when TLS is not configured")
+	}
+
+	// If TLS is configured, but not already in use, STARTTLS should appear.
+	s.srv.TLSConfig = &tls.Config{}
+	extensions = parseExtensions(t, s.makeEHLOResponse())
+	if _, ok := extensions["STARTTLS"]; !ok {
+		t.Errorf("STARTTLS does not appear in the extension list when TLS is configured")
+	}
+
+	// If TLS is already used on the connection, STARTTLS should not appear.
+	s.tls = true
+	extensions = parseExtensions(t, s.makeEHLOResponse())
+	if _, ok := extensions["STARTTLS"]; ok {
+		t.Errorf("STARTTLS appears in the extension list when TLS is already in use")
+	}
+
+	// Verify default SIZE extension is zero.
+	s.srv = &Server{}
+	extensions = parseExtensions(t, s.makeEHLOResponse())
+	if _, ok := extensions["SIZE"]; !ok {
+		t.Errorf("SIZE does not appear in the extension list")
+	} else if extensions["SIZE"] != "0" {
+		t.Errorf("SIZE appears in the extension list with incorrect parameter %s, want %s", extensions["SIZE"], "0")
+	}
+
+	// Verify configured maximum message size is listed correctly.
+	// Any integer will suffice, as long as it's not hardcoded.
+	maxSize := 10 + time.Now().Minute()
+	maxSizeStr := fmt.Sprintf("%d", maxSize)
+	s.srv = &Server{MaxSize: maxSize}
+	extensions = parseExtensions(t, s.makeEHLOResponse())
+	if _, ok := extensions["SIZE"]; !ok {
+		t.Errorf("SIZE does not appear in the extension list")
+	} else if extensions["SIZE"] != maxSizeStr {
+		t.Errorf("SIZE appears in the extension list with incorrect parameter %s, want %s", extensions["SIZE"], maxSizeStr)
+	}
+
+	// With no authentication handler configured, AUTH should not be advertised.
+	s.srv = &Server{}
+	extensions = parseExtensions(t, s.makeEHLOResponse())
+	if _, ok := extensions["AUTH"]; ok {
+		t.Errorf("AUTH appears in the extension list when no AuthHandler is specified")
+	}
+
+	// With an authentication handler configured, AUTH should be advertised.
+	s.srv = &Server{AuthHandler: authHandler}
+	extensions = parseExtensions(t, s.makeEHLOResponse())
+	if _, ok := extensions["AUTH"]; !ok {
+		t.Errorf("AUTH does not appear in the extension list when an AuthHandler is specified")
+	}
+
+	reLogin := regexp.MustCompile("\\bLOGIN\\b")
+	rePlain := regexp.MustCompile("\\bPLAIN\\b")
+
+	// RFC 4954 specifies that, without TLS in use, plaintext authentication mechanisms must not be advertised.
+	s.tls = false
+	extensions = parseExtensions(t, s.makeEHLOResponse())
+	if reLogin.MatchString(extensions["AUTH"]) {
+		t.Errorf("AUTH mechanism LOGIN appears in the extension list when an AuthHandler is specified and TLS is not in use")
+	}
+	if rePlain.MatchString(extensions["AUTH"]) {
+		t.Errorf("AUTH mechanism PLAIN appears in the extension list when an AuthHandler is specified and TLS is not in use")
+	}
+
+	// RFC 4954 specifies that, with TLS in use, plaintext authentication mechanisms can be advertised.
+	s.tls = true
+	extensions = parseExtensions(t, s.makeEHLOResponse())
+	if !reLogin.MatchString(extensions["AUTH"]) {
+		t.Errorf("AUTH mechanism LOGIN does not appear in the extension list when an AuthHandler is specified and TLS is in use")
+	}
+	if !rePlain.MatchString(extensions["AUTH"]) {
+		t.Errorf("AUTH mechanism PLAIN does not appear in the extension list when an AuthHandler is specified and TLS is in use")
+	}
+}
+
+func createTmpFile(content string) (file *os.File, err error) {
+	file, err = ioutil.TempFile("", "")
+	if err != nil {
+		return
+	}
+	_, err = file.Write([]byte(content))
+	if err != nil {
+		return
+	}
+	err = file.Close()
+	return
+}
+
+func createTLSFiles() (
+	certFile *os.File,
+	keyFile *os.File,
+	passphrase string,
+	err error,
+) {
+	const certPEM = `-----BEGIN CERTIFICATE-----
+MIIDRzCCAi+gAwIBAgIJAKtg4oViVwv4MA0GCSqGSIb3DQEBCwUAMBQxEjAQBgNV
+BAMMCWxvY2FsaG9zdDAgFw0xODA0MjAxMzMxNTBaGA8yMDg2MDUwODEzMzE1MFow
+FDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
+CgKCAQEA8h7vl0gUquis5jRtcnETyD+8WITZO0s53aIzp0Y+9HXiHW6FGJjbOZjM
+IvozNVni+83QWKumRTgeSzIIW2j4V8iFMSNrvWmhmCKloesXS1aY6H979e01Ve8J
+WAJFRe6vZJd6gC6Z/P+ELU3ie4Vtr1GYfkV7nZ6VFp5/V/5nxGFag5TUlpP5hcoS
+9r2kvXofosVwe3x3udT8SEbv5eBD4bKeVyJs/RLbxSuiU1358Y1cDdVuHjcvfm3c
+ajhheQ4vX9WXsk7LGGhnf1SrrPN/y+IDTXfvoHn+nJh4vMAB4yzQdE1V1N1AB8RA
+0yBVJ6dwxRrSg4BFrNWhj3gfsvrA7wIDAQABo4GZMIGWMB0GA1UdDgQWBBQ4/ncp
+befFuKH1hoYkPqLwuRrPRjAfBgNVHSMEGDAWgBQ4/ncpbefFuKH1hoYkPqLwuRrP
+RjAJBgNVHRMEAjAAMBEGCWCGSAGG+EIBAQQEAwIGQDALBgNVHQ8EBAMCBaAwEwYD
+VR0lBAwwCgYIKwYBBQUHAwEwFAYDVR0RBA0wC4IJbG9jYWxob3N0MA0GCSqGSIb3
+DQEBCwUAA4IBAQBJBetEXiEIzKAEpXGX87j6aUON51Fdf6BiLMCghuGKyhnaOG32
+4KJhtvVoS3ZUKPylh9c2VdItYlhWp76zd7YKk+3xUOixWeTMQHIvCvRGTyFibOPT
+mApwp2pEnJCe4vjUrBaRhiyI+xnB70cWVF2qeernlLUeJA1mfYyQLz+v06ebDWOL
+c/hPVQFB94lEdiyjGO7RZfIe8KwcK48g7iv0LQU4+c9MoWM2ZsVM1AL2tHzokSeA
+u64gDTW4K0Tzx1ab7KmOFXYUjbz/xWuReMt33EwDXAErKCjbVt2T55Qx8UoKzSh1
+tY0KDHdnYOzgsm2HIj2xcJqbeylYQvckNnoC
+-----END CERTIFICATE-----`
+
+	const keyPEM = `-----BEGIN RSA PRIVATE KEY-----
+Proc-Type: 4,ENCRYPTED
+DEK-Info: AES-256-CBC,C16BF8745B2CDB53AC2B1D7609893AA0
+
+O13z7Yq7butaJmMfg9wRis9YnIDPsp4coYI6Ud+JGcP7iXoy95QMhovKWx25o1ol
+tvUTsrsG27fHGf9qG02KizApIVtO9c1e0swCWzFrKRQX0JDiZDmilb9xosBNNst1
+BOzOTRZEwFGSOCKZRBfSXyqC93TvLJ3DO9IUnKIeGt7upipvg29b/Dur/fyCy2WV
+bLHXwUTDBm7j49yfoEyGkDjoB2QO9wgcgbacbnQJQ25fTFUwZpZJEJv6o1tRhoYM
+ZMOhC9x1URmdHKN1+z2y5BrB6oNpParfeAMEvs/9FE6jJwYUR28Ql6Mhphfvr9W2
+5Gxd3J65Ao9Vi2I5j5X6aBuNjyhXN3ScLjPG4lVZm9RU/uTPEt81pig/d5nSAjvF
+Nfc08NuG3cnMyJSE/xScJ4D+GtX8U969wO4oKPCR4E/NFyXPR730ppupDFG6hzPD
+PDmiszDtU438JAZ8AuFa1LkbyFnEW6KVD4h7VRr8YDjirCqnkgjNSI6dFY0NQ8H7
+SyexB0lrceX6HZc+oNdAtkX3tYdzY3ExzUM5lSF1dkldnRbApLbqc4uuNIVXhXFM
+dJnoPdKAzM6i+2EeVUxWNdafKDxnjVSHIHzHfIFJLQ4GS5rnz9keRFdyDjQL07tT
+Lu9pPOmsadDXp7oSa81RgoCUfNZeR4jKpCk2BOft0L6ZSqwYFLcQHLIfJaGfn902
+TUOTxHt0KzEUYeYSrXC2a6cyvXAd1YI7lOgy60qG89VHyCc2v5Bs4c4FNUDC/+Dj
+4ZwogaAbSNkLaE0q3sYQRPdxSqLftyX0KitAgE7oGtdzBfe1cdBoozw3U67NEMMT
+6qvk5j7RepPRSrapHtK5pMMdg5XpKFWcOXZ26VHVrDCj4JKdjVb4iyiQi94VveV0
+w9+KcOtyrM7/jbQlCWnXpsIkP8VA/RIgh7CBn/h4oF1sO8ywP25OGQ7VWAVq1R9D
+8bl8GzIdR9PZpFyOxuIac4rPa8tkDeoXKs4cxoao7H/OZO9o9aTB7CJMTL9yv0Kb
+ntWuYxQchE6syoGsOgdGyZhaw4JeFkasDUP5beyNY+278NkzgGTOIMMTXIX46woP
+ehzHKGHXVGf7ZiSFF+zAHMXZRSwNVMkOYwlIoRg1IbvIRbAXqAR6xXQTCVzNG0SU
+cskojycBca1Cz3hDVIKYZd9beDhprVdr2a4K2nft2g2xRNjKPopsaqXx+VPibFUx
+X7542eQ3eAlhkWUuXvt0q5a9WJdjJp9ODA0/d0akF6JQlEHIAyLfoUKB1HYwgUGG
+6uRm651FDAab9U4cVC5PY1hfv/QwzpkNDkzgJAZ5SMOfZhq7IdBcqGd3lzPmq2FP
+Vy1LVZIl3eM+9uJx5TLsBHH6NhMwtNhFCNa/5ksodQYlTvR8IrrgWlYg4EL69vjS
+yt6HhhEN3lFCWvrQXQMp93UklbTlpVt6qcDXiC7HYbs3+EINargRd5Z+xL5i5vkN
+f9k7s0xqhloWNPZcyOXMrox8L81WOY+sP4mVlGcfDRLdEJ8X2ofJpOAcwYCnjsKd
+uEGsi+l2fTj/F+eZLE6sYoMprgJrbfeqtRWFguUgTn7s5hfU0tZ46al5d0vz8fWK
+-----END RSA PRIVATE KEY-----`
+
+	passphrase = "test"
+
+	certFile, err = createTmpFile(certPEM)
+	if err != nil {
+		return
+	}
+	keyFile, err = createTmpFile(keyPEM)
+	return
+}
+
+func TestConfigureTLSWithPassphrase(t *testing.T) {
+	certFile, keyFile, passphrase, err := createTLSFiles()
+	if err != nil {
+		t.Errorf("Unexpected TLS files creation error: %s", err)
+		return
+	}
+	defer func() {
+		os.Remove(certFile.Name())
+		os.Remove(keyFile.Name())
+	}()
+	srv := &Server{}
+	err = srv.ConfigureTLSWithPassphrase(
+		certFile.Name(),
+		keyFile.Name(),
+		passphrase,
+	)
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if srv.TLSConfig == nil {
+		t.Errorf("Unexpected empty TLS config.")
+	}
+}
+
+func TestAuthMechs(t *testing.T) {
+	s := session{}
+	s.srv = &Server{}
+
+	// Validate that non-TLS (default) configuration does not allow plaintext authentication mechanisms.
+	correct := map[string]bool{"LOGIN": false, "PLAIN": false, "CRAM-MD5": true}
+	mechs := s.authMechs()
+	if !reflect.DeepEqual(mechs, correct) {
+		t.Errorf("authMechs() returned %v, want %v", mechs, correct)
+	}
+
+	// Validate that TLS configuration allows plaintext authentication mechanisms.
+	correct = map[string]bool{"LOGIN": true, "PLAIN": true, "CRAM-MD5": true}
+	s.tls = true
+	mechs = s.authMechs()
+	if !reflect.DeepEqual(mechs, correct) {
+		t.Errorf("authMechs() returned %v, want %v", mechs, correct)
+	}
+
+	// Validate that overridden values take precedence over RFC compliance when not using TLS.
+	correct = map[string]bool{"LOGIN": true, "PLAIN": true, "CRAM-MD5": false}
+	s.tls = false
+	s.srv.AuthMechs = map[string]bool{"LOGIN": true, "PLAIN": true, "CRAM-MD5": false}
+	mechs = s.authMechs()
+	if !reflect.DeepEqual(mechs, correct) {
+		t.Errorf("authMechs() returned %v, want %v", mechs, correct)
+	}
+
+	// Validate that overridden values take precedence over RFC compliance when using TLS.
+	correct = map[string]bool{"LOGIN": false, "PLAIN": false, "CRAM-MD5": true}
+	s.tls = true
+	s.srv.AuthMechs = map[string]bool{"LOGIN": false, "PLAIN": false, "CRAM-MD5": true}
+	mechs = s.authMechs()
+	if !reflect.DeepEqual(mechs, correct) {
+		t.Errorf("authMechs() returned %v, want %v", mechs, correct)
+	}
+
+	// Validate ability to explicitly disallow all mechanisms.
+	correct = map[string]bool{"LOGIN": false, "PLAIN": false, "CRAM-MD5": false}
+	s.srv.AuthMechs = map[string]bool{"LOGIN": false, "PLAIN": false, "CRAM-MD5": false}
+	mechs = s.authMechs()
+	if !reflect.DeepEqual(mechs, correct) {
+		t.Errorf("authMechs() returned %v, want %v", mechs, correct)
+	}
+
+	// Validate ability to explicitly allow all mechanisms.
+	correct = map[string]bool{"LOGIN": true, "PLAIN": true, "CRAM-MD5": true}
+	s.srv.AuthMechs = map[string]bool{"LOGIN": true, "PLAIN": true, "CRAM-MD5": true}
+	mechs = s.authMechs()
+	if !reflect.DeepEqual(mechs, correct) {
+		t.Errorf("authMechs() returned %v, want %v", mechs, correct)
+	}
+}
+
+func TestCmdAUTH(t *testing.T) {
+	server := &Server{}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// By default no authentication handler is configured, so AUTH should return 502 not implemented.
+	cmdCode(t, conn, "AUTH", "502")
+
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdAUTHOptional(t *testing.T) {
+	server := &Server{AuthHandler: authHandler}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// AUTH without mechanism parameter must return 501 syntax error.
+	cmdCode(t, conn, "AUTH", "501")
+
+	// AUTH with a supported mechanism should return 334.
+	cmdCode(t, conn, "AUTH CRAM-MD5", "334")
+
+	// AUTH must support cancellation with '*' and return 501 syntax error.
+	cmdCode(t, conn, "*", "501")
+
+	// AUTH with an unsupported mechanism should return 504 unrecognized type.
+	cmdCode(t, conn, "AUTH FOO", "504")
+
+	// The LOGIN and PLAIN mechanisms require a TLS connection, and are disabled by default.
+	cmdCode(t, conn, "AUTH LOGIN", "504")
+	cmdCode(t, conn, "AUTH PLAIN", "504")
+
+	// AUTH attempt during a mail transaction must return 503 bad sequence.
+	cmdCode(t, conn, "MAIL FROM:<sender@example.com>", "250")
+	cmdCode(t, conn, "AUTH CRAM-MD5", "503")
+	cmdCode(t, conn, "RCPT TO:<recipient@example.com>", "250")
+	cmdCode(t, conn, "AUTH CRAM-MD5", "503")
+
+	// AUTH after a mail transaction must return 334.
+	// TODO: Work out what should happen if AUTH is received after DATA.
+	cmdCode(t, conn, "DATA", "354")
+	cmdCode(t, conn, "Test message\r\n.", "250")
+	cmdCode(t, conn, "AUTH CRAM-MD5", "334")
+
+	// Cancel the authentication attempt, otherwise the QUIT below will return 502.
+	// TODO: Work out what should happen if QUIT is received after AUTH.
+	cmdCode(t, conn, "*", "501")
+
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdAUTHRequired(t *testing.T) {
+	server := &Server{AuthHandler: authHandler, AuthRequired: true}
+	conn := newConn(t, server)
+
+	tests := []struct {
+		cmd        string
+		codeBefore string
+		codeAfter  string
+	}{
+		{"EHLO host.example.com", "250", "250"},
+		{"NOOP", "250", "250"},
+		{"MAIL FROM:<sender@example.com>", "530", "250"},
+		{"RCPT TO:<recipient@example.com>", "530", "250"},
+		{"RSET", "250", "250"}, // Reset before DATA to avoid having to actually send a message.
+		{"DATA", "530", "503"},
+		{"HELP", "502", "502"},
+		{"VRFY", "502", "502"},
+		{"EXPN", "502", "502"},
+		{"TEST", "500", "500"},     // Unsupported command
+		{"", "500", "500"},         // Blank command
+		{"STARTTLS", "502", "502"}, // TLS not configured
+	}
+
+	// If authentication is configured and required, but not already in use, reject every command except
+	// AUTH, EHLO, HELO, NOOP, RSET, or QUIT as per RFC 4954.
+	for _, tt := range tests {
+		cmdCode(t, conn, tt.cmd, tt.codeBefore)
+	}
+
+	// AUTH without mechanism parameter must return 501 syntax error.
+	cmdCode(t, conn, "AUTH", "501")
+
+	// AUTH with a supported mechanism should return 334.
+	cmdCode(t, conn, "AUTH CRAM-MD5", "334")
+
+	// AUTH must support cancellation with '*' and return 501 syntax error.
+	cmdCode(t, conn, "*", "501")
+
+	// AUTH with an unsupported mechanism should return 504 unrecognized type.
+	cmdCode(t, conn, "AUTH FOO", "504")
+
+	// The LOGIN and PLAIN mechanisms require a TLS connection, and are disabled by default.
+	cmdCode(t, conn, "AUTH LOGIN", "504")
+	cmdCode(t, conn, "AUTH PLAIN", "504")
+
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdAUTHLOGIN(t *testing.T) {
+	server := &Server{TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}}, AuthHandler: authHandler}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// AUTH LOGIN without TLS in use must return 504 unrecognised type.
+	cmdCode(t, conn, "AUTH LOGIN", "504")
+
+	// Upgrade to TLS.
+	cmdCode(t, conn, "STARTTLS", "220")
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	err := tlsConn.Handshake()
+	if err != nil {
+		t.Errorf("Failed to perform TLS handshake")
+	}
+	cmdCode(t, tlsConn, "EHLO host.example.com", "250")
+
+	// AUTH LOGIN with TLS in use can proceed.
+
+	// LOGIN authentication process:
+	// Client sends "AUTH LOGIN"
+	// Server sends "334 VXNlcm5hbWU6" (Base64-encoded "Username:").
+	// Client sends Base64-encoded username.
+	// Server sends "334 UGFzc3dvcmQ6" (Base64-encoded "Password:").
+	// Client sends Base64-encoded password.
+	invalidBase64 := "==" // Invalid Base64 string.
+	validUsername := base64.StdEncoding.EncodeToString([]byte("valid"))
+	invalidUsername := base64.StdEncoding.EncodeToString([]byte("invalid"))
+	password := base64.StdEncoding.EncodeToString([]byte("password"))
+
+	// Corrupt credentials must return 501 syntax error.
+	cmdCode(t, tlsConn, "AUTH LOGIN", "334")
+	cmdCode(t, tlsConn, invalidBase64, "501")
+
+	cmdCode(t, tlsConn, "AUTH LOGIN", "334")
+	cmdCode(t, tlsConn, validUsername, "334")
+	cmdCode(t, tlsConn, invalidBase64, "501")
+
+	// Invalid credentials must return 535 authentication credentials invalid.
+	cmdCode(t, tlsConn, "AUTH LOGIN", "334")
+	cmdCode(t, tlsConn, invalidUsername, "334")
+	cmdCode(t, tlsConn, password, "535")
+
+	// Valid credentials must return 235 authentication succeeded.
+	cmdCode(t, tlsConn, "AUTH LOGIN", "334")
+	cmdCode(t, tlsConn, validUsername, "334")
+	cmdCode(t, tlsConn, password, "235")
+
+	// AUTH after prior successful AUTH must return 503 bad sequence.
+	cmdCode(t, tlsConn, "AUTH LOGIN", "503")
+	cmdCode(t, tlsConn, "AUTH PLAIN", "503")
+	cmdCode(t, tlsConn, "AUTH CRAM-MD5", "503")
+
+	cmdCode(t, tlsConn, "QUIT", "221")
+	tlsConn.Close()
+}
+
+func TestCmdAUTHLOGINFast(t *testing.T) {
+	server := &Server{TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}}, AuthHandler: authHandler}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// AUTH LOGIN without TLS in use must return 504 unrecognised type.
+	cmdCode(t, conn, "AUTH LOGIN", "504")
+
+	// Upgrade to TLS.
+	cmdCode(t, conn, "STARTTLS", "220")
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	err := tlsConn.Handshake()
+	if err != nil {
+		t.Errorf("Failed to perform TLS handshake")
+	}
+	cmdCode(t, tlsConn, "EHLO host.example.com", "250")
+
+	// AUTH LOGIN with TLS in use can proceed.
+
+	// Fast LOGIN authentication process:
+	// Client sends "AUTH LOGIN " plus Base64-encoded username.
+	// Server sends "334 UGFzc3dvcmQ6" (Base64-encoded "Password:").
+	// Client sends Base64-encoded password.
+	invalidBase64 := "==" // Invalid Base64 string.
+	validUsername := base64.StdEncoding.EncodeToString([]byte("valid"))
+	invalidUsername := base64.StdEncoding.EncodeToString([]byte("invalid"))
+	password := base64.StdEncoding.EncodeToString([]byte("password"))
+
+	// Corrupt credentials must return 501 syntax error.
+	cmdCode(t, tlsConn, "AUTH LOGIN "+invalidBase64, "501")
+
+	cmdCode(t, tlsConn, "AUTH LOGIN "+validUsername, "334")
+	cmdCode(t, tlsConn, invalidBase64, "501")
+
+	// Invalid credentials must return 535 authentication credentials invalid.
+	cmdCode(t, tlsConn, "AUTH LOGIN "+invalidUsername, "334")
+	cmdCode(t, tlsConn, password, "535")
+
+	// Valid credentials must return 235 authentication succeeded.
+	cmdCode(t, tlsConn, "AUTH LOGIN", "334")
+	cmdCode(t, tlsConn, validUsername, "334")
+	cmdCode(t, tlsConn, password, "235")
+
+	// AUTH after prior successful AUTH must return 503 bad sequence.
+	cmdCode(t, tlsConn, "AUTH LOGIN", "503")
+	cmdCode(t, tlsConn, "AUTH PLAIN", "503")
+	cmdCode(t, tlsConn, "AUTH CRAM-MD5", "503")
+
+	cmdCode(t, tlsConn, "QUIT", "221")
+	tlsConn.Close()
+}
+
+func TestCmdAUTHPLAIN(t *testing.T) {
+	server := &Server{TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}}, AuthHandler: authHandler}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// AUTH PLAIN without TLS in use must return 504 unrecognised type.
+	cmdCode(t, conn, "AUTH PLAIN", "504")
+
+	// Upgrade to TLS.
+	cmdCode(t, conn, "STARTTLS", "220")
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	err := tlsConn.Handshake()
+	if err != nil {
+		t.Errorf("Failed to perform TLS handshake")
+	}
+	cmdCode(t, tlsConn, "EHLO host.example.com", "250")
+
+	// AUTH PLAIN with TLS in use can proceed.
+	// RFC 2595 specifies:
+	// The client sends the authorization identity (identity to
+	// login as), followed by a US-ASCII NUL character, followed by the
+	// authentication identity (identity whose password will be used),
+	// followed by a US-ASCII NUL character, followed by the clear-text
+	// password.  The client may leave the authorization identity empty to
+	// indicate that it is the same as the authentication identity.
+
+	// PLAIN authentication process:
+	// Client sends "AUTH PLAIN"
+	// Server sends "334 " (RFC 4954 requires the space).
+	// Client sends Base64-encoded string: identity\0username\0password
+	invalidBase64 := "==" // Invalid Base64 string.
+	missingNUL := base64.StdEncoding.EncodeToString([]byte("valid\x00password"))
+	valid := base64.StdEncoding.EncodeToString([]byte("identity\x00valid\x00password"))
+	invalid := base64.StdEncoding.EncodeToString([]byte("identity\x00invalid\x00password"))
+
+	// Corrupt credentials must return 501 syntax error.
+	cmdCode(t, tlsConn, "AUTH PLAIN", "334")
+	cmdCode(t, tlsConn, invalidBase64, "501")
+
+	cmdCode(t, tlsConn, "AUTH PLAIN", "334")
+	cmdCode(t, tlsConn, missingNUL, "501")
+
+	// Invalid credentials must return 535 authentication credentials invalid.
+	cmdCode(t, tlsConn, "AUTH PLAIN", "334")
+	cmdCode(t, tlsConn, invalid, "535")
+
+	// Valid credentials must return 235 authentication succeeded.
+	cmdCode(t, tlsConn, "AUTH PLAIN", "334")
+	cmdCode(t, tlsConn, valid, "235")
+
+	// AUTH after prior successful AUTH must return 503 bad sequence.
+	cmdCode(t, tlsConn, "AUTH LOGIN", "503")
+	cmdCode(t, tlsConn, "AUTH PLAIN", "503")
+	cmdCode(t, tlsConn, "AUTH CRAM-MD5", "503")
+
+	cmdCode(t, tlsConn, "QUIT", "221")
+	tlsConn.Close()
+}
+
+func TestCmdAUTHPLAINEmpty(t *testing.T) {
+	server := &Server{TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}}, AuthHandler: authHandler}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// AUTH PLAIN without TLS in use must return 504 unrecognised type.
+	cmdCode(t, conn, "AUTH PLAIN", "504")
+
+	// Upgrade to TLS.
+	cmdCode(t, conn, "STARTTLS", "220")
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	err := tlsConn.Handshake()
+	if err != nil {
+		t.Errorf("Failed to perform TLS handshake")
+	}
+	cmdCode(t, tlsConn, "EHLO host.example.com", "250")
+
+	// AUTH PLAIN with TLS in use can proceed.
+	// RFC 2595 specifies:
+	// The client sends the authorization identity (identity to
+	// login as), followed by a US-ASCII NUL character, followed by the
+	// authentication identity (identity whose password will be used),
+	// followed by a US-ASCII NUL character, followed by the clear-text
+	// password.  The client may leave the authorization identity empty to
+	// indicate that it is the same as the authentication identity.
+
+	// PLAIN authentication process with empty authorisation identity:
+	// Client sends "AUTH PLAIN"
+	// Server sends "334 " (RFC 4954 requires the space).
+	// Client sends Base64-encoded string: \0username\0password
+	invalidBase64 := "==" // Invalid Base64 string.
+	missingNUL := base64.StdEncoding.EncodeToString([]byte("valid\x00password"))
+	valid := base64.StdEncoding.EncodeToString([]byte("\x00valid\x00password"))
+	invalid := base64.StdEncoding.EncodeToString([]byte("\x00invalid\x00password"))
+
+	// Corrupt credentials must return 501 syntax error.
+	cmdCode(t, tlsConn, "AUTH PLAIN", "334")
+	cmdCode(t, tlsConn, invalidBase64, "501")
+
+	cmdCode(t, tlsConn, "AUTH PLAIN", "334")
+	cmdCode(t, tlsConn, missingNUL, "501")
+
+	// Invalid credentials must return 535 authentication credentials invalid.
+	cmdCode(t, tlsConn, "AUTH PLAIN", "334")
+	cmdCode(t, tlsConn, invalid, "535")
+
+	// Valid credentials must return 235 authentication succeeded.
+	cmdCode(t, tlsConn, "AUTH PLAIN", "334")
+	cmdCode(t, tlsConn, valid, "235")
+
+	// AUTH after prior successful AUTH must return 503 bad sequence.
+	cmdCode(t, tlsConn, "AUTH LOGIN", "503")
+	cmdCode(t, tlsConn, "AUTH PLAIN", "503")
+	cmdCode(t, tlsConn, "AUTH CRAM-MD5", "503")
+
+	cmdCode(t, tlsConn, "QUIT", "221")
+	tlsConn.Close()
+}
+
+func TestCmdAUTHPLAINFast(t *testing.T) {
+	server := &Server{TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}}, AuthHandler: authHandler}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// AUTH PLAIN without TLS in use must return 504 unrecognised type.
+	cmdCode(t, conn, "AUTH PLAIN", "504")
+
+	// Upgrade to TLS.
+	cmdCode(t, conn, "STARTTLS", "220")
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	err := tlsConn.Handshake()
+	if err != nil {
+		t.Errorf("Failed to perform TLS handshake")
+	}
+	cmdCode(t, tlsConn, "EHLO host.example.com", "250")
+
+	// AUTH PLAIN with TLS in use can proceed.
+	// RFC 2595 specifies:
+	// The client sends the authorization identity (identity to
+	// login as), followed by a US-ASCII NUL character, followed by the
+	// authentication identity (identity whose password will be used),
+	// followed by a US-ASCII NUL character, followed by the clear-text
+	// password.  The client may leave the authorization identity empty to
+	// indicate that it is the same as the authentication identity.
+
+	// Fast PLAIN authentication process:
+	// Client sends "AUTH PLAIN " plus Base64-encoded string: identity\0username\0password
+	invalidBase64 := "==" // Invalid Base64 string.
+	missingNUL := base64.StdEncoding.EncodeToString([]byte("valid\x00password"))
+	valid := base64.StdEncoding.EncodeToString([]byte("identity\x00valid\x00password"))
+	invalid := base64.StdEncoding.EncodeToString([]byte("identity\x00invalid\x00password"))
+
+	// Corrupt credentials must return 501 syntax error.
+	cmdCode(t, tlsConn, "AUTH PLAIN "+invalidBase64, "501")
+	cmdCode(t, tlsConn, "AUTH PLAIN "+missingNUL, "501")
+
+	// Invalid credentials must return 535 authentication credentials invalid.
+	cmdCode(t, tlsConn, "AUTH PLAIN "+invalid, "535")
+
+	// Valid credentials must return 235 authentication succeeded.
+	cmdCode(t, tlsConn, "AUTH PLAIN "+valid, "235")
+
+	// AUTH after prior successful AUTH must return 503 bad sequence.
+	cmdCode(t, tlsConn, "AUTH LOGIN", "503")
+	cmdCode(t, tlsConn, "AUTH PLAIN", "503")
+	cmdCode(t, tlsConn, "AUTH CRAM-MD5", "503")
+
+	cmdCode(t, tlsConn, "QUIT", "221")
+	tlsConn.Close()
+}
+
+func TestCmdAUTHPLAINFastAndEmpty(t *testing.T) {
+	server := &Server{TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}}, AuthHandler: authHandler}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// AUTH PLAIN without TLS in use must return 504 unrecognised type.
+	cmdCode(t, conn, "AUTH PLAIN", "504")
+
+	// Upgrade to TLS.
+	cmdCode(t, conn, "STARTTLS", "220")
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	err := tlsConn.Handshake()
+	if err != nil {
+		t.Errorf("Failed to perform TLS handshake")
+	}
+	cmdCode(t, tlsConn, "EHLO host.example.com", "250")
+
+	// AUTH PLAIN with TLS in use can proceed.
+	// RFC 2595 specifies:
+	// The client sends the authorization identity (identity to
+	// login as), followed by a US-ASCII NUL character, followed by the
+	// authentication identity (identity whose password will be used),
+	// followed by a US-ASCII NUL character, followed by the clear-text
+	// password.  The client may leave the authorization identity empty to
+	// indicate that it is the same as the authentication identity.
+
+	// Fast PLAIN authentication process with empty authorisation identity:
+	// Client sends "AUTH PLAIN " plus Base64-encoded string: \0username\0password
+	invalidBase64 := "==" // Invalid Base64 string.
+	missingNUL := base64.StdEncoding.EncodeToString([]byte("valid\x00password"))
+	valid := base64.StdEncoding.EncodeToString([]byte("\x00valid\x00password"))
+	invalid := base64.StdEncoding.EncodeToString([]byte("\x00invalid\x00password"))
+
+	// Corrupt credentials must return 501 syntax error.
+	cmdCode(t, tlsConn, "AUTH PLAIN "+invalidBase64, "501")
+	cmdCode(t, tlsConn, "AUTH PLAIN "+missingNUL, "501")
+
+	// Invalid credentials must return 535 authentication credentials invalid.
+	cmdCode(t, tlsConn, "AUTH PLAIN "+invalid, "535")
+
+	// Valid credentials must return 235 authentication succeeded.
+	cmdCode(t, tlsConn, "AUTH PLAIN "+valid, "235")
+
+	// AUTH after prior successful AUTH must return 503 bad sequence.
+	cmdCode(t, tlsConn, "AUTH LOGIN", "503")
+	cmdCode(t, tlsConn, "AUTH PLAIN", "503")
+	cmdCode(t, tlsConn, "AUTH CRAM-MD5", "503")
+
+	cmdCode(t, tlsConn, "QUIT", "221")
+	tlsConn.Close()
+}
+
+// makeCRAMMD5Response is a helper function to create the CRAM-MD5 hash.
+func makeCRAMMD5Response(challenge string, username string, secret string) (string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(challenge)
+	if err != nil {
+		return "", err
+	}
+	hash := hmac.New(md5.New, []byte(secret))
+	hash.Write(decoded)
+	buffer := make([]byte, 0, hash.Size())
+	response := fmt.Sprintf("%s %x", username, hash.Sum(buffer))
+	return base64.StdEncoding.EncodeToString([]byte(response)), nil
+}
+
+func TestCmdAUTHCRAMMD5(t *testing.T) {
+	server := &Server{AuthHandler: authHandler}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// AUTH CRAM-MD5 without TLS in use can proceed.
+	// RFC 2195 specifies:
+	// The challenge format is that of a Message-ID email header value.
+	// Challenge format: '<' + random digits + '.' + timestamp in digits + '@' + fully-qualified server hostname + '>'
+	// Challenge example: <1896.697170952@postoffice.reston.mci.net>
+	// The response format consists of the username, a space and a digest.
+	// Digest calculation: MD5((secret XOR opad), MD5((secret XOR ipad), challenge))
+	// Response example: tim b913a602c7eda7a495b4e6e7334d3890
+
+	// CRAM-MD5 authentication process:
+	// Client sends "AUTH CRAM-MD5".
+	// Server sends "334 " plus Base64-encoded challenge.
+	// Client sends Base64-encoded response.
+	invalidBase64 := "==" // Invalid Base64 string.
+
+	// Corrupt credentials must return 501 syntax error.
+	cmdCode(t, conn, "AUTH CRAM-MD5", "334")
+	cmdCode(t, conn, invalidBase64, "501")
+
+	// Test valid credentials with missing space (causing a parse error).
+	line := cmdCode(t, conn, "AUTH CRAM-MD5", "334")
+	valid, _ := makeCRAMMD5Response(line[4:], "valid", "password")
+	buffer, _ := base64.StdEncoding.DecodeString(valid)
+	buffer = bytes.Replace(buffer, []byte(" "), []byte(""), 1)
+	missingSpace := base64.StdEncoding.EncodeToString(buffer)
+	cmdCode(t, conn, string(missingSpace), "501")
+
+	// Invalid credentials must return 535 authentication credentials invalid.
+	line = cmdCode(t, conn, "AUTH CRAM-MD5", "334")
+	invalid, err := makeCRAMMD5Response(line[4:], "invalid", "password")
+	if err != nil {
+		cmdCode(t, conn, "*", "501")
+	}
+	cmdCode(t, conn, invalid, "535")
+
+	// Valid credentials must return 235 authentication succeeded.
+	line = cmdCode(t, conn, "AUTH CRAM-MD5", "334")
+	valid, err = makeCRAMMD5Response(line[4:], "valid", "password")
+	if err != nil {
+		cmdCode(t, conn, "*", "501")
+	}
+	cmdCode(t, conn, valid, "235")
+
+	// AUTH after prior successful AUTH must return 503 bad sequence.
+	cmdCode(t, conn, "AUTH LOGIN", "503")
+	cmdCode(t, conn, "AUTH PLAIN", "503")
+	cmdCode(t, conn, "AUTH CRAM-MD5", "503")
+
+	cmdCode(t, conn, "QUIT", "221")
+	conn.Close()
+}
+
+func TestCmdAUTHCRAMMD5WithTLS(t *testing.T) {
+	server := &Server{TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}}, AuthHandler: authHandler}
+	conn := newConn(t, server)
+	cmdCode(t, conn, "EHLO host.example.com", "250")
+
+	// Upgrade to TLS.
+	cmdCode(t, conn, "STARTTLS", "220")
+	tlsConn := tls.Client(conn, &tls.Config{InsecureSkipVerify: true})
+	err := tlsConn.Handshake()
+	if err != nil {
+		t.Errorf("Failed to perform TLS handshake")
+	}
+	cmdCode(t, tlsConn, "EHLO host.example.com", "250")
+
+	// AUTH CRAM-MD5 with TLS in use can proceed.
+	// RFC 2195 specifies:
+	// The challenge format is that of a Message-ID email header value.
+	// Challenge format: '<' + random digits + '.' + timestamp in digits + '@' + fully-qualified server hostname + '>'
+	// Challenge example: <1896.697170952@postoffice.reston.mci.net>
+	// The response format consists of the username, a space and a digest.
+	// Digest calculation: MD5((secret XOR opad), MD5((secret XOR ipad), challenge))
+	// Response example: tim b913a602c7eda7a495b4e6e7334d3890
+
+	// CRAM-MD5 authentication process:
+	// Client sends "AUTH CRAM-MD5".
+	// Server sends "334 " plus Base64-encoded challenge.
+	// Client sends Base64-encoded response.
+	invalidBase64 := "==" // Invalid Base64 string.
+
+	// Corrupt credentials must return 501 syntax error.
+	cmdCode(t, tlsConn, "AUTH CRAM-MD5", "334")
+	cmdCode(t, tlsConn, invalidBase64, "501")
+
+	// Test valid credentials with missing space (causing a parse error).
+	line := cmdCode(t, tlsConn, "AUTH CRAM-MD5", "334")
+	valid, _ := makeCRAMMD5Response(line[4:], "valid", "password")
+	buffer, _ := base64.StdEncoding.DecodeString(valid)
+	buffer = bytes.Replace(buffer, []byte(" "), []byte(""), 1)
+	missingSpace := base64.StdEncoding.EncodeToString(buffer)
+	cmdCode(t, tlsConn, string(missingSpace), "501")
+
+	// Invalid credentials must return 535 authentication credentials invalid.
+	line = cmdCode(t, tlsConn, "AUTH CRAM-MD5", "334")
+	invalid, err := makeCRAMMD5Response(line[4:], "invalid", "password")
+	if err != nil {
+		cmdCode(t, tlsConn, "*", "501")
+	}
+	cmdCode(t, tlsConn, invalid, "535")
+
+	// Valid credentials must return 235 authentication succeeded.
+	line = cmdCode(t, tlsConn, "AUTH CRAM-MD5", "334")
+	valid, err = makeCRAMMD5Response(line[4:], "valid", "password")
+	if err != nil {
+		cmdCode(t, tlsConn, "*", "501")
+	}
+	cmdCode(t, tlsConn, valid, "235")
+
+	// AUTH after prior successful AUTH must return 503 bad sequence.
+	cmdCode(t, tlsConn, "AUTH LOGIN", "503")
+	cmdCode(t, tlsConn, "AUTH PLAIN", "503")
+	cmdCode(t, tlsConn, "AUTH CRAM-MD5", "503")
+
+	cmdCode(t, tlsConn, "QUIT", "221")
+	tlsConn.Close()
+}
+
+// Benchmark the mail handling without the network stack introducing latency.
+func BenchmarkReceive(b *testing.B) {
+	server := &Server{} // Default server configuration.
+	clientConn, serverConn := net.Pipe()
+	session := server.newSession(serverConn)
+	go session.serve()
+
+	reader := bufio.NewReader(clientConn)
+	_, _ = reader.ReadString('\n') // Read greeting message first.
+
+	b.ResetTimer()
+
+	// Benchmark a full mail transaction.
+	for i := 0; i < b.N; i++ {
+		fmt.Fprintf(clientConn, "%s\r\n", "HELO host.example.com")
+		_, _ = reader.ReadString('\n')
+		fmt.Fprintf(clientConn, "%s\r\n", "MAIL FROM:<sender@example.com>")
+		_, _ = reader.ReadString('\n')
+		fmt.Fprintf(clientConn, "%s\r\n", "RCPT TO:<recipient@example.com>")
+		_, _ = reader.ReadString('\n')
+		fmt.Fprintf(clientConn, "%s\r\n", "DATA")
+		_, _ = reader.ReadString('\n')
+		fmt.Fprintf(clientConn, "%s\r\n", "Test message.\r\n.")
+		_, _ = reader.ReadString('\n')
+		fmt.Fprintf(clientConn, "%s\r\n", "QUIT")
+		_, _ = reader.ReadString('\n')
+	}
+}


### PR DESCRIPTION
## Summary
- vendor smtpd library under `internal/smtpd`
- modify library to accept `SMTPUTF8` parameter in `MAIL FROM`
- advertise `SMTPUTF8` capability in EHLO responses
- replace upstream smtpd module with local version

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6854fd7023a0832eb64d6749180bdb2e